### PR TITLE
Remove OnPropertyChanged for IsScanning

### DIFF
--- a/BarcodeScanner.Mobile.XamarinForms/Shared/CameraView.cs
+++ b/BarcodeScanner.Mobile.XamarinForms/Shared/CameraView.cs
@@ -89,8 +89,7 @@ namespace BarcodeScanner.Mobile.XamarinForms
             , typeof(bool)
             , typeof(CameraView)
             , true
-            , defaultBindingMode: BindingMode.TwoWay
-            , propertyChanged: (bindable, value, newValue) => ((CameraView)bindable).IsScanning = (bool)newValue);
+            , defaultBindingMode: BindingMode.TwoWay);
         /// <summary>
         /// Disables or enables scanning
         /// </summary>


### PR DESCRIPTION
Hi @JimmyPun610, we are using your plugin in our Xamarin.Forms app and after the release we were getting System.NullReferenceException while changing"IsScanning" for more than 500 users on Android.
I do not know the exact steps to reproduce, because it never happens on local devices in our team, but according to the stack trace and based on the code I assumed that "newValue" sometimes is null and therefore is a crash.
Overriding "IsScanning" properly and omitting casting newValue to bool helped.
Also, these onPropertyChanged for every method are not needed, because properties are updating just fine. If you would like to leave them, it is better to add validation to "binadble" and "newValue" whether they are null or not. 
Please let me know what you think about it

Here is the error log and stack trace:
CameraView.set_IsScanning (System.Boolean value)
System.NullReferenceException: Object reference not set to an instance of an object

BindableObject.SetValueCore (Xamarin.Forms.BindableProperty property, System.Object value, Xamarin.Forms.Internals.SetValueFlags attributes, Xamarin.Forms.BindableObject+SetValuePrivateFlags privateAttributes)
BindableObject.SetValue (Xamarin.Forms.BindableProperty property, System.Object value, System.Boolean fromStyle, System.Boolean checkAccess)
BindableObject.SetValue (Xamarin.Forms.BindableProperty property, System.Object value)
CameraView.set_IsScanning (System.Boolean value)
CameraViewRenderer+BarcodeAnalyzer.Analyze (AndroidX.Camera.Core.IImageProxy proxy)
AsyncMethodBuilderCore+<>c.<ThrowAsync>b__7_1 (System.Object state)
QueueUserWorkItemCallback.WaitCallback_Context (System.Object state)
ExecutionContext.RunInternal (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx)
ExecutionContext.Run (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx)
IThreadPoolWorkItem.ExecuteWorkItem ()
ThreadPoolWorkQueue.Dispatch ()
_ThreadPoolWaitCallback.PerformWaitCallback ()

