### PR TITLE
Exception when opening a camera view when on a simulator.

### DIFF
--- a/BarcodeScanner.Mobile.XamarinForms/iOS/Renderer/CameraViewRenderer.cs
+++ b/BarcodeScanner.Mobile.XamarinForms/iOS/Renderer/CameraViewRenderer.cs
@@ -3,6 +3,7 @@ using Xamarin.Forms;
 using Xamarin.Forms.Platform.iOS;
 using BarcodeScanner.Mobile.XamarinForms;
 using BarcodeScanner.Mobile.Core;
+using ObjCRuntime;
 
 
 [assembly: ExportRenderer(typeof(CameraView), typeof(BarcodeScanner.Mobile.XamarinForms.Renderer.CameraViewRenderer))]

--- a/BarcodeScanner.Mobile.XamarinForms/iOS/Renderer/CameraViewRenderer.cs
+++ b/BarcodeScanner.Mobile.XamarinForms/iOS/Renderer/CameraViewRenderer.cs
@@ -15,6 +15,8 @@ namespace BarcodeScanner.Mobile.XamarinForms.Renderer
 
         protected override void OnElementChanged(ElementChangedEventArgs<CameraView> e)
         {
+            if (Runtime.Arch == Arch.SIMULATOR) return;
+            
             base.OnElementChanged(e);
             if (e.OldElement != null || Element == null)
             {
@@ -37,6 +39,8 @@ namespace BarcodeScanner.Mobile.XamarinForms.Renderer
 
         protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
+            if (Runtime.Arch == Arch.SIMULATOR) return;
+            
             base.OnElementPropertyChanged(sender, e);
             if (e.PropertyName == CameraView.TorchOnProperty.PropertyName)
             {


### PR DESCRIPTION
When a page is opened with the CameraView in it, on an IOS simulator, the app crashes with the error 'The selected camera is not supported on this device', with the stacktrace shown below. To fix this, I added a check at the start of OnElementChanged and OnElementPropertyChanged, which checks if the device is a simulator. If the device is a simulator, it returns from these functions, so there will be no attempts to create a camera view on a simulator. 

If there is another way to solve this issue I would love to hear it, but this solved the issue for me. I only had this issue for IOS, because on IOS we use simulators for testing, and also apple uses them to check submissions. Maybe it is also an issue on android emulators, but I haven't looked into that. Would be great if this is put in a future release on nuget. 

<pre><code>
  at BarcodeScanner.Mobile.XamarinForms.UICameraPreview.AddInputToCameraSession (BarcodeScanner.Mobile.Core.CameraFacing facing) [0x00036] in <0da8bf9f43494b61a948d685e8df88d2>:0 
  at BarcodeScanner.Mobile.XamarinForms.UICameraPreview.Initialize (BarcodeScanner.Mobile.XamarinForms.Renderer.CameraViewRenderer renderer) [0x00074] in <0da8bf9f43494b61a948d685e8df88d2>:0 
  at BarcodeScanner.Mobile.XamarinForms.UICameraPreview..ctor (BarcodeScanner.Mobile.XamarinForms.Renderer.CameraViewRenderer renderer, BarcodeScanner.Mobile.Core.CameraFacing cameraFacing, BarcodeScanner.Mobile.Core.CaptureQuality captureQuality) [0x00014] in <0da8bf9f43494b61a948d685e8df88d2>:0 
  at BarcodeScanner.Mobile.XamarinForms.Renderer.CameraViewRenderer.OnElementChanged (Xamarin.Forms.Platform.iOS.ElementChangedEventArgs`1[TElement] e) [0x0005c] in <0da8bf9f43494b61a948d685e8df88d2>:0 
  at Xamarin.Forms.Platform.iOS.VisualElementRenderer`1[TElement].SetElement (TElement element) [0x00172] in D:\a\1\s\Xamarin.Forms.Platform.iOS\VisualElementRenderer.cs:296 
  at Xamarin.Forms.Platform.iOS.VisualElementRenderer`1[TElement].Xamarin.Forms.Platform.iOS.IVisualElementRenderer.SetElement (Xamarin.Forms.VisualElement element) [0x00000] in D:\a\1\s\Xamarin.Forms.Platform.iOS\VisualElementRenderer.cs:158 
  at Xamarin.Forms.Platform.iOS.Platform.CreateRenderer (Xamarin.Forms.VisualElement element) [0x00032] in D:\a\1\s\Xamarin.Forms.Platform.iOS\Platform.cs:240 
  at Xamarin.Forms.Platform.iOS.VisualElementPackager.OnChildAdded (Xamarin.Forms.VisualElement view) [0x0003e] in D:\a\1\s\Xamarin.Forms.Platform.iOS\VisualElementPackager.cs:119 
  at Xamarin.Forms.Platform.iOS.VisualElementPackager.Load () [0x0001e] in D:\a\1\s\Xamarin.Forms.Platform.iOS\VisualElementPackager.cs:51 
  at Xamarin.Forms.Platform.iOS.VisualElementRenderer`1[TElement].SetElement (TElement element) [0x0012e] in D:\a\1\s\Xamarin.Forms.Platform.iOS\VisualElementRenderer.cs:283 
  at Xamarin.Forms.Platform.iOS.VisualElementRenderer`1[TElement].Xamarin.Forms.Platform.iOS.IVisualElementRenderer.SetElement (Xamarin.Forms.VisualElement element) [0x00000] in D:\a\1\s\Xamarin.Forms.Platform.iOS\VisualElementRenderer.cs:158 
  at Xamarin.Forms.Platform.iOS.Platform.CreateRenderer (Xamarin.Forms.VisualElement element) [0x00032] in D:\a\1\s\Xamarin.Forms.Platform.iOS\Platform.cs:240 
  at Xamarin.Forms.Platform.iOS.VisualElementPackager.OnChildAdded (Xamarin.Forms.VisualElement view) [0x0003e] in D:\a\1\s\Xamarin.Forms.Platform.iOS\VisualElementPackager.cs:119 
  at Xamarin.Forms.Platform.iOS.VisualElementPackager.Load () [0x0001e] in D:\a\1\s\Xamarin.Forms.Platform.iOS\VisualElementPackager.cs:51 
  at Xamarin.Forms.Platform.iOS.VisualElementRenderer`1[TElement].SetElement (TElement element) [0x0012e] in D:\a\1\s\Xamarin.Forms.Platform.iOS\VisualElementRenderer.cs:283 
  at Xamarin.Forms.Platform.iOS.VisualElementRenderer`1[TElement].Xamarin.Forms.Platform.iOS.IVisualElementRenderer.SetElement (Xamarin.Forms.VisualElement element) [0x00000] in D:\a\1\s\Xamarin.Forms.Platform.iOS\VisualElementRenderer.cs:158 
  at Xamarin.Forms.Platform.iOS.Platform.CreateRenderer (Xamarin.Forms.VisualElement element) [0x00032] in D:\a\1\s\Xamarin.Forms.Platform.iOS\Platform.cs:240 
  at Xamarin.Forms.Platform.iOS.VisualElementPackager.OnChildAdded (Xamarin.Forms.VisualElement view) [0x0003e] in D:\a\1\s\Xamarin.Forms.Platform.iOS\VisualElementPackager.cs:119 
  at Xamarin.Forms.Platform.iOS.VisualElementPackager.Load () [0x0001e] in D:\a\1\s\Xamarin.Forms.Platform.iOS\VisualElementPackager.cs:51 
  at Xamarin.Forms.Platform.iOS.VisualElementRenderer`1[TElement].SetElement (TElement element) [0x0012e] in D:\a\1\s\Xamarin.Forms.Platform.iOS\VisualElementRenderer.cs:283 
  at Xamarin.Forms.Platform.iOS.VisualElementRenderer`1[TElement].Xamarin.Forms.Platform.iOS.IVisualElementRenderer.SetElement (Xamarin.Forms.VisualElement element) [0x00000] in D:\a\1\s\Xamarin.Forms.Platform.iOS\VisualElementRenderer.cs:158 
  at Xamarin.Forms.Platform.iOS.Platform.CreateRenderer (Xamarin.Forms.VisualElement element) [0x00032] in D:\a\1\s\Xamarin.Forms.Platform.iOS\Platform.cs:240 
  at Xamarin.Forms.Platform.iOS.VisualElementPackager.OnChildAdded (Xamarin.Forms.VisualElement view) [0x0003e] in D:\a\1\s\Xamarin.Forms.Platform.iOS\VisualElementPackager.cs:119 
  at Xamarin.Forms.Platform.iOS.VisualElementPackager.Load () [0x0001e] in D:\a\1\s\Xamarin.Forms.Platform.iOS\VisualElementPackager.cs:51 
  at Xamarin.Forms.Platform.iOS.PageRenderer.ViewDidLoad () [0x0008f] in D:\a\1\s\Xamarin.Forms.Platform.iOS\Renderers\PageRenderer.cs:252 
  at (wrapper managed-to-native) ObjCRuntime.Messaging.IntPtr_objc_msgSendSuper(intptr,intptr)
  at UIKit.UIViewController.get_View () [0x0002a] in /Library/Frameworks/Xamarin.iOS.framework/Versions/16.0.0.72/src/Xamarin.iOS/UIKit/UIViewController.g.cs:2910 
  at Xamarin.Forms.Platform.iOS.PageRenderer.get_NativeView () [0x00000] in D:\a\1\s\Xamarin.Forms.Platform.iOS\Renderers\PageRenderer.cs:104 
  at Xamarin.Forms.Platform.iOS.PageRenderer.SetElement (Xamarin.Forms.VisualElement element) [0x0003d] in D:\a\1\s\Xamarin.Forms.Platform.iOS\Renderers\PageRenderer.cs:120 
  at Xamarin.Forms.Platform.iOS.Platform.CreateRenderer (Xamarin.Forms.VisualElement element) [0x00032] in D:\a\1\s\Xamarin.Forms.Platform.iOS\Platform.cs:240 
  at Xamarin.Forms.Platform.iOS.ShellSectionRootRenderer.SetPageRenderer (Xamarin.Forms.Page page, Xamarin.Forms.ShellContent shellContent) [0x00013] in D:\a\1\s\Xamarin.Forms.Platform.iOS\Renderers\ShellSectionRootRenderer.cs:497 
  at Xamarin.Forms.Platform.iOS.ShellSectionRootRenderer.LoadRenderers () [0x0009c] in D:\a\1\s\Xamarin.Forms.Platform.iOS\Renderers\ShellSectionRootRenderer.cs:244 
  at Xamarin.Forms.Platform.iOS.ShellSectionRootRenderer.ViewDidLoad () [0x00077] in D:\a\1\s\Xamarin.Forms.Platform.iOS\Renderers\ShellSectionRootRenderer.cs:81 
  at (wrapper managed-to-native) UIKit.UIApplication.xamarin_UIApplicationMain(int,string[],intptr,intptr,intptr&)
  at UIKit.UIApplication.UIApplicationMain (System.Int32 argc, System.String[] argv, System.IntPtr principalClassName, System.IntPtr delegateClassName) [0x00000] in /Library/Frameworks/Xamarin.iOS.framework/Versions/16.0.0.72/src/Xamarin.iOS/UIKit/UIApplication.cs:57 
  at UIKit.UIApplication.Main (System.String[] args, System.Type principalClass, System.Type delegateClass) [0x0003b] in /Library/Frameworks/Xamarin.iOS.framework/Versions/16.0.0.72/src/Xamarin.iOS/UIKit/UIApplication.cs:92 
  at AdamsApp.iOS.Application.Main (System.String[] args) [0x00001] in C:\Users\stef\Source\Repos\AdamsApp\AdamsApp.iOS\Main.cs:13 
</pre></code>