### PR TITLE
Fix NRE on emulators

### DIFF
--- a/BarcodeScanner.Mobile.Maui/Platforms/Android/CameraViewHandler.android.cs
+++ b/BarcodeScanner.Mobile.Maui/Platforms/Android/CameraViewHandler.android.cs
@@ -35,8 +35,6 @@ namespace BarcodeScanner.Mobile
 
         private void Connect()
         {
-            if (DeviceInfo.Current.DeviceType == DeviceType.Virtual)
-                return;
             _cameraExecutor = Executors.NewSingleThreadExecutor();
             _cameraFuture = ProcessCameraProvider.GetInstance(Context);
             _cameraFuture.AddListener(new Runnable(CameraCallback), ContextCompat.GetMainExecutor(Context));

--- a/BarcodeScanner.Mobile.Maui/Platforms/Android/CameraViewHandler.android.cs
+++ b/BarcodeScanner.Mobile.Maui/Platforms/Android/CameraViewHandler.android.cs
@@ -11,11 +11,6 @@ using BarcodeScanner.Mobile.Platforms.Android;
 using Google.Common.Util.Concurrent;
 using Java.Lang;
 using Java.Util.Concurrent;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Exception = System.Exception;
 
 namespace BarcodeScanner.Mobile
@@ -29,15 +24,15 @@ namespace BarcodeScanner.Mobile
 
         private ICamera _camera;
 
-        PreviewView previewView;
+        PreviewView _previewView;
 
         protected override PreviewView CreatePlatformView()
         {
-            previewView = new PreviewView(Context);
-            return previewView;
+            _previewView = new PreviewView(Context);
+            return _previewView;
         }
 
-        
+
         private void Connect()
         {
             if (DeviceInfo.Current.DeviceType == DeviceType.Virtual)
@@ -53,13 +48,13 @@ namespace BarcodeScanner.Mobile
                 return;
 
             // Used to bind the lifecycle of cameras to the lifecycle owner
-            if (!(_cameraFuture.Get() is ProcessCameraProvider cameraProvider))
+            if (_cameraFuture?.Get() is not ProcessCameraProvider cameraProvider)
                 return;
 
             // Preview
             var previewBuilder = new Preview.Builder();
             var preview = previewBuilder.Build();
-            preview.SetSurfaceProvider(previewView.SurfaceProvider);
+            preview.SetSurfaceProvider(_previewView.SurfaceProvider);
 
             var imageAnalyzerBuilder = new ImageAnalysis.Builder();
             // Frame by frame analyze
@@ -132,12 +127,14 @@ namespace BarcodeScanner.Mobile
                 _ => throw new ArgumentOutOfRangeException(nameof(CaptureQuality))
             };
         }
+
         public void HandleTorch()
         {
             if (_camera == null || VirtualView == null || !_camera.CameraInfo.HasFlashUnit) return;
            
             _camera.CameraControl.EnableTorch(VirtualView.TorchOn);
         }
+
         private bool IsTorchOn()
         {
             if (_camera == null || !_camera.CameraInfo.HasFlashUnit)
@@ -187,7 +184,7 @@ namespace BarcodeScanner.Mobile
             try
             {
                 // Used to bind the lifecycle of cameras to the lifecycle owner
-                if (!(_cameraFuture.Get() is ProcessCameraProvider cameraProvider))
+                if (_cameraFuture?.Get() is not ProcessCameraProvider cameraProvider)
                     return;
 
                 cameraProvider.UnbindAll();

--- a/BarcodeScanner.Mobile.XamarinForms/Android/Renderer/CameraViewRenderer.cs
+++ b/BarcodeScanner.Mobile.XamarinForms/Android/Renderer/CameraViewRenderer.cs
@@ -49,10 +49,6 @@ namespace BarcodeScanner.Mobile.Renderer
 
         protected override void OnElementChanged(ElementChangedEventArgs<BarcodeScanner.Mobile.CameraView> e)
         {
-
-            if (Build.Model.Contains("Emulator") || Build.Model.Contains("Android SDK"))
-                return;
-
             base.OnElementChanged(e);
 
             if (e.NewElement == null) return;
@@ -68,9 +64,6 @@ namespace BarcodeScanner.Mobile.Renderer
 
         protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            if (Build.Model.Contains("Emulator") || Build.Model.Contains("Android SDK"))
-                return;
-
             base.OnElementPropertyChanged(sender, e);
             if (e.PropertyName == BarcodeScanner.Mobile.CameraView.TorchOnProperty.PropertyName)
             {


### PR DESCRIPTION
Fixes NullReferenceExeption on android emulators
```csharp
System.NullReferenceException: Object reference not set to an instance of an object.
    at BarcodeScanner.Mobile.CameraViewHandler.CameraCallback()
```

@JimmyPun610  Do you know why the android handler is blocked on the emulator?
```csharp
           if (DeviceInfo.Current.DeviceType == DeviceType.Virtual)
              return;
```
update:
Removed restriction from android emulators since Camera working just fine with the android emulator, moreover you can use a webcam on PC to use in the emulator