### PR TITLE
Update CameraX for MAUI to latest and use ResolutionSelector for picking correct resolution

### DIFF
--- a/BarcodeScanner.Mobile.Maui/BarcodeScanner.Mobile.Maui.csproj
+++ b/BarcodeScanner.Mobile.Maui/BarcodeScanner.Mobile.Maui.csproj
@@ -43,13 +43,15 @@
 
 	<!-- Going to use latest version library in MAUI -->
 	<ItemGroup Condition="( '$(TargetFramework)' == 'net8.0-android' )">
-		<PackageReference Include="Xamarin.AndroidX.Camera.Camera2" Version="1.1.0">
+		<PackageReference Include="Xamarin.AndroidX.Camera.Camera2" Version="1.3.0.1">
 		</PackageReference>
-		<PackageReference Include="Xamarin.AndroidX.Camera.Lifecycle" Version="1.1.0">
+		<PackageReference Include="Xamarin.AndroidX.Camera.Lifecycle" Version="1.3.0.1">
 		</PackageReference>
-		<PackageReference Include="Xamarin.AndroidX.Camera.View" Version="1.1.0">
+		<PackageReference Include="Xamarin.AndroidX.Camera.View" Version="1.3.0.1">
 		</PackageReference>
-		<PackageReference Include="Xamarin.Google.MLKit.BarcodeScanning" Version="117.0.2.2">
+		<PackageReference Include="Xamarin.Google.MLKit.BarcodeScanning" Version="117.2.0.2">
+		</PackageReference>
+		<PackageReference Include="Xamarin.GooglePlayServices.MLKit.Text.Recognition" Version="119.0.0.4">			
 		</PackageReference>
 	</ItemGroup>
 
@@ -84,11 +86,6 @@
 	  </Compile>
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
-	  <PackageReference Include="Xamarin.GooglePlayServices.MLKit.Text.Recognition">
-	    <Version>118.0.1</Version>
-	  </PackageReference>
-	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />

--- a/BarcodeScanner.Mobile.Maui/Platforms/Android/BarcodeAnalyzer.cs
+++ b/BarcodeScanner.Mobile.Maui/Platforms/Android/BarcodeAnalyzer.cs
@@ -1,4 +1,3 @@
-using Android.App;
 using Android.Graphics;
 using Android.Runtime;
 using Android.Util;
@@ -10,7 +9,7 @@ using Xamarin.Google.MLKit.Vision.Text;
 using static BarcodeScanner.Mobile.OCRMethods;
 using Size = Android.Util.Size;
 
-namespace BarcodeScanner.Mobile.Platforms.Android
+namespace BarcodeScanner.Mobile
 {
     public class BarcodeAnalyzer : Java.Lang.Object, ImageAnalysis.IAnalyzer
     {
@@ -68,7 +67,7 @@ namespace BarcodeScanner.Mobile.Platforms.Android
                     if (!_cameraView.IsScanning)
                         return;
 
-                    var imageData = new byte[0];
+                    var imageData = Array.Empty<byte>();
                     if (_cameraView.ReturnBarcodeImage)
                     {
                         imageData = NV21toJPEG(YUV_420_888toNV21(mediaImage), mediaImage.Width, mediaImage.Height);
@@ -124,7 +123,7 @@ namespace BarcodeScanner.Mobile.Platforms.Android
         /// </summary>
         private static byte[] NV21toJPEG(byte[] nv21, int width, int height)
         {
-            MemoryStream outstran = new MemoryStream();
+            using MemoryStream outstran = new MemoryStream();
             YuvImage yuv = new YuvImage(nv21, ImageFormatType.Nv21, width, height, null);
             yuv.CompressToJpeg(new global::Android.Graphics.Rect(0, 0, width, height), 100, outstran);
             return outstran.ToArray();

--- a/BarcodeScanner.Mobile.Maui/Platforms/Android/Methods.cs
+++ b/BarcodeScanner.Mobile.Maui/Platforms/Android/Methods.cs
@@ -1,7 +1,6 @@
 ﻿using Android.Gms.Extensions;
 using Android.Graphics;
 using Android.Runtime;
-using Java.Nio;
 using Java.Util;
 using Xamarin.Google.MLKit.Vision.Barcode.Common;
 using Xamarin.Google.MLKit.Vision.BarCode;

--- a/BarcodeScanner.Mobile.Maui/Platforms/Android/OCRMethods.cs
+++ b/BarcodeScanner.Mobile.Maui/Platforms/Android/OCRMethods.cs
@@ -1,15 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Xamarin.Google.MLKit.Vision.Text;
+﻿using Xamarin.Google.MLKit.Vision.Text;
 using Android.Gms.Tasks;
 using Android.Util;
-using BarcodeScanner.Mobile.Platforms.Android;
 using Xamarin.Google.MLKit.Vision.Common;
 using Android.Graphics;
-using Xamarin.Google.MLKit.Vision.BarCode;
 using Android.Gms.Extensions;
 using static BarcodeScanner.Mobile.OCRResult;
 

--- a/BarcodeScanner.Mobile.Maui/Platforms/Android/TaskCompleteListener.cs
+++ b/BarcodeScanner.Mobile.Maui/Platforms/Android/TaskCompleteListener.cs
@@ -1,11 +1,6 @@
 ﻿using Android.Gms.Tasks;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace BarcodeScanner.Mobile.Platforms.Android
+namespace BarcodeScanner.Mobile
 {
     internal class TaskCompleteListener : Java.Lang.Object, IOnCompleteListener
     {

--- a/BarcodeScanner.Mobile.Maui/Platforms/Android/TorchStateObserver.cs
+++ b/BarcodeScanner.Mobile.Maui/Platforms/Android/TorchStateObserver.cs
@@ -1,12 +1,7 @@
 ﻿using AndroidX.Camera.Core;
 using AndroidX.Lifecycle;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace BarcodeScanner.Mobile.Platforms.Android
+namespace BarcodeScanner.Mobile
 {
     internal class TorchStateObserver : Java.Lang.Object, IObserver
     {

--- a/BarcodeScanner.Mobile.Maui/Platforms/iOS/CameraViewHandler.ios.cs
+++ b/BarcodeScanner.Mobile.Maui/Platforms/iOS/CameraViewHandler.ios.cs
@@ -2,12 +2,6 @@
 using BarcodeScanner.Mobile.Platforms.iOS;
 using CoreVideo;
 using Foundation;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using UIKit;
 
 namespace BarcodeScanner.Mobile
 {
@@ -120,6 +114,7 @@ namespace BarcodeScanner.Mobile
             {
                 CaptureQuality.Lowest => AVCaptureSession.Preset352x288,
                 CaptureQuality.Low => AVCaptureSession.Preset640x480,
+                CaptureQuality.Default => AVCaptureSession.Preset1280x720,
                 CaptureQuality.Medium => AVCaptureSession.Preset1280x720,
                 CaptureQuality.High => AVCaptureSession.Preset1920x1080,
                 CaptureQuality.Highest => AVCaptureSession.Preset3840x2160,

--- a/BarcodeScanner.Mobile.Maui/Platforms/iOS/Methods.cs
+++ b/BarcodeScanner.Mobile.Maui/Platforms/iOS/Methods.cs
@@ -1,5 +1,4 @@
-﻿using CoreGraphics;
-using Foundation;
+﻿using Foundation;
 using MLKit.BarcodeScanning;
 using MLKit.Core;
 using UIKit;

--- a/BarcodeScanner.Mobile.Maui/Platforms/iOS/OCRMethods.cs
+++ b/BarcodeScanner.Mobile.Maui/Platforms/iOS/OCRMethods.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Foundation;
+﻿using Foundation;
 using UIKit;
 using Vision;
 
@@ -16,7 +15,7 @@ namespace BarcodeScanner.Mobile
             if (result.GetType() != typeof(VNRecognizeTextRequest))
                 return ocrResult; //only interested in text
 
-            if (result.GetResults<VNRecognizedTextObservation>().Count() < 1)
+            if (!result.GetResults<VNRecognizedTextObservation>().Any())
                 return ocrResult;
 
             foreach(var o in result.GetResults<VNRecognizedTextObservation>())

--- a/BarcodeScanner.Mobile.Maui/Platforms/iOS/UICameraPreview.cs
+++ b/BarcodeScanner.Mobile.Maui/Platforms/iOS/UICameraPreview.cs
@@ -1,9 +1,4 @@
 ﻿using AVFoundation;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using UIKit;
 
 namespace BarcodeScanner.Mobile.Platforms.iOS

--- a/BarcodeScanner.Mobile.Maui/Shared/CameraView.cs
+++ b/BarcodeScanner.Mobile.Maui/Shared/CameraView.cs
@@ -28,25 +28,6 @@ namespace BarcodeScanner.Mobile
             set => SetValue(VibrationOnDetectedProperty, value);
         }
 
-        public static BindableProperty PreviewHeightProperty = BindableProperty.Create(nameof(PreviewHeight), typeof(int?), typeof(CameraView), null);
-        /// <summary>
-        /// Only Android will be reflected this setting
-        /// </summary>
-        public int? PreviewHeight
-        {
-            get => (int?)GetValue(PreviewHeightProperty);
-            set => SetValue(PreviewHeightProperty, value);
-        }
-
-        public static BindableProperty PreviewWidthProperty = BindableProperty.Create(nameof(PreviewWidth), typeof(int?), typeof(CameraView), null);
-        /// <summary>
-        /// Only Android will be reflected this setting
-        /// </summary>
-        public int? PreviewWidth
-        {
-            get => (int?)GetValue(PreviewWidthProperty);
-            set => SetValue(PreviewWidthProperty, value);
-        }
 
         public static BindableProperty RequestedFPSProperty = BindableProperty.Create(nameof(RequestedFPS)
             , typeof(float?)

--- a/BarcodeScanner.Mobile.Maui/Shared/CameraView.cs
+++ b/BarcodeScanner.Mobile.Maui/Shared/CameraView.cs
@@ -158,7 +158,7 @@ namespace BarcodeScanner.Mobile
         public static BindableProperty CaptureQualityProperty = BindableProperty.Create(nameof(CaptureQuality)
             , typeof(CaptureQuality)
             , typeof(CameraView)
-            , CaptureQuality.Medium
+            , CaptureQuality.Default
             , defaultBindingMode: BindingMode.TwoWay
             , propertyChanged: (bindable, value, newValue) => ((CameraView)bindable).CaptureQuality = (CaptureQuality)newValue);
 

--- a/BarcodeScanner.Mobile.Maui/Shared/CameraViewHandler.cs
+++ b/BarcodeScanner.Mobile.Maui/Shared/CameraViewHandler.cs
@@ -34,7 +34,7 @@ namespace BarcodeScanner.Mobile
         {
         }
 
-   
+
         public CameraViewHandler(PropertyMapper mapper = null) : base(mapper ?? CameraViewMapper)
         {
         }

--- a/BarcodeScanner.Mobile.Maui/Shared/CaptureQuality.cs
+++ b/BarcodeScanner.Mobile.Maui/Shared/CaptureQuality.cs
@@ -2,10 +2,11 @@
 {
     public enum CaptureQuality
     {
-        Lowest = 0,
-        Low = 1,
-        Medium = 2,
-        High = 3,
-        Highest = 4,
+        Default = 0,
+        Lowest = 1,
+        Low = 2,
+        Medium = 3,
+        High = 4,
+        Highest = 5
     }
 }

--- a/BarcodeScanner.Mobile.Maui/Shared/Extensions.cs
+++ b/BarcodeScanner.Mobile.Maui/Shared/Extensions.cs
@@ -1,9 +1,6 @@
-﻿using Microsoft.Maui.Controls.Compatibility.Hosting;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿#if ANDROID
+using AndroidX.Camera.Core.ResolutionSelector;
+#endif
 
 namespace BarcodeScanner.Mobile
 {
@@ -21,10 +18,29 @@ namespace BarcodeScanner.Mobile
             CaptureQuality.Lowest => new Android.Util.Size(352, 288),
             CaptureQuality.Low => new Android.Util.Size(640, 480),
             CaptureQuality.Medium => new Android.Util.Size(1280, 720),
+            CaptureQuality.Default => new Android.Util.Size(1280, 720),
             CaptureQuality.High => new Android.Util.Size(1920, 1080),
             CaptureQuality.Highest => new Android.Util.Size(3840, 2160),
             _ => throw new ArgumentOutOfRangeException(nameof(CaptureQuality))
         };
+
+
+        public static ResolutionStrategy GetTargetResolutionStrategy(this CaptureQuality quality)
+        {
+            switch (quality)
+            {
+                case CaptureQuality.Default:
+                    return ResolutionStrategy.HighestAvailableStrategy;
+                case CaptureQuality.Lowest:
+                case CaptureQuality.Low:
+                case CaptureQuality.Medium:
+                case CaptureQuality.High:
+                case CaptureQuality.Highest:
+                    return new ResolutionStrategy(GetTargetResolution(quality), ResolutionStrategy.FallbackRuleClosestHigher);
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(CaptureQuality));
+            }
+        }
 #endif
     }
 }

--- a/BarcodeScanner.Mobile.Maui/Shared/ICameraView.cs
+++ b/BarcodeScanner.Mobile.Maui/Shared/ICameraView.cs
@@ -9,18 +9,6 @@ namespace BarcodeScanner.Mobile
         public static BindableProperty VibrationOnDetectedProperty { get; set; }
         public bool VibrationOnDetected { get; set; }
 
-        public static BindableProperty PreviewHeightProperty { get; set; }
-        /// <summary>
-        /// Only Android will be reflected this setting
-        /// </summary>
-        public int? PreviewHeight { get; set; }
-
-        public static BindableProperty PreviewWidthProperty { get; set; }
-        /// <summary>
-        /// Only Android will be reflected this setting
-        /// </summary>
-        public int? PreviewWidth { get; set; }
-
         public static BindableProperty RequestedFPSProperty { get; set; }
         /// <summary>
         /// Only Android will be reflected this setting

--- a/BarcodeScanner.Mobile.Maui/Shared/ICameraView.cs
+++ b/BarcodeScanner.Mobile.Maui/Shared/ICameraView.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Input;
+﻿using System.Windows.Input;
 
 namespace BarcodeScanner.Mobile
 {

--- a/BarcodeScanner.Mobile.Maui/Shared/OCRResult.cs
+++ b/BarcodeScanner.Mobile.Maui/Shared/OCRResult.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace BarcodeScanner.Mobile
+﻿namespace BarcodeScanner.Mobile
 {
     public class OCRResult
     {

--- a/BarcodeScanner.Mobile.Maui/Shared/OnDetectedEventArg.cs
+++ b/BarcodeScanner.Mobile.Maui/Shared/OnDetectedEventArg.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BarcodeScanner.Mobile
+﻿namespace BarcodeScanner.Mobile
 {
     public class OnDetectedEventArg : EventArgs
     {

--- a/BarcodeScanner.Mobile.XamarinForms/Android/Renderer/CameraViewRenderer.cs
+++ b/BarcodeScanner.Mobile.XamarinForms/Android/Renderer/CameraViewRenderer.cs
@@ -404,7 +404,7 @@ namespace BarcodeScanner.Mobile.Renderer
             /// </summary>
             private static byte[] NV21toJPEG(byte[] nv21, int width, int height)
             {
-                MemoryStream outstran = new MemoryStream();
+                using MemoryStream outstran = new MemoryStream();
                 YuvImage yuv = new YuvImage(nv21, ImageFormatType.Nv21, width, height, null);
                 yuv.CompressToJpeg(new Android.Graphics.Rect(0, 0, width, height), 100, outstran);
                 return outstran.ToArray();

--- a/SampleApp.Maui/MainPage.xaml
+++ b/SampleApp.Maui/MainPage.xaml
@@ -4,7 +4,8 @@
              x:Class="SampleApp.Maui.MainPage">
 
     <ScrollView>
-        <StackLayout>
+        <StackLayout Spacing="10"
+                     Margin="10,0">
             <!-- Place new controls here -->
             <Button Text="Scan Continously" Clicked="Button1_Clicked"/>
             <Button Text="Scan One time" Clicked="Button2_Clicked"/>

--- a/SampleApp.Maui/Mvvm/MvvmDemo.xaml
+++ b/SampleApp.Maui/Mvvm/MvvmDemo.xaml
@@ -10,7 +10,7 @@
     </ContentPage.BindingContext>
     <ContentPage.Content>
 
-        <Grid HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand">
+        <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="*"/>
@@ -62,10 +62,10 @@
             </StackLayout>
             <!--Fill the screen with CameraView-->
             <gv:CameraView Grid.Row="1" Grid.Column="1"
-                           OnDetectedCommand="{Binding OnDetectCommand}" 
-                           IsScanning="{Binding IsScanning}" 
-                           TorchOn="{Binding TorchOn}" VibrationOnDetected="{Binding VibrationOnDetected}" ScanInterval="{Binding ScanInterval}"
-                           x:Name="Camera" HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand"/>
+                    OnDetectedCommand="{Binding OnDetectCommand}" 
+                    IsScanning="{Binding IsScanning}" 
+                    TorchOn="{Binding TorchOn}" VibrationOnDetected="{Binding VibrationOnDetected}" ScanInterval="{Binding ScanInterval}"
+                    x:Name="Camera" />
             <!--Customized Size-->
             <!--<gv:CameraView HorizontalOptions="Center" WidthRequest="200" HeightRequest="200" OnDetected="CameraView_OnDetected" Grid.Row="1"/>-->
             <StackLayout Grid.Row="2" HeightRequest="120" Grid.ColumnSpan="3">

--- a/SampleApp.Maui/Page1.xaml
+++ b/SampleApp.Maui/Page1.xaml
@@ -4,23 +4,40 @@
              x:Class="SampleApp.Maui.Page1"
              xmlns:gv="clr-namespace:BarcodeScanner.Mobile;assembly=BarcodeScanner.Mobile.Maui"
              Title="Page1">
-    <Grid HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand">
+    <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
-        <StackLayout Orientation="Horizontal" HorizontalOptions="FillAndExpand" Grid.Row="0">
-            <Button x:Name="CancelButton" Text="Cancel" BackgroundColor="#FF0000" TextColor="White" Clicked="CancelButton_Clicked" HorizontalOptions="StartAndExpand"
-                        CornerRadius="0"/>
-            <Button x:Name="FlashlightButton" Text="Flashlight" BackgroundColor="#0075FF" TextColor="White" Clicked="FlashlightButton_Clicked" HorizontalOptions="CenterAndExpand"
-                        CornerRadius="0"/>
-            <Button x:Name="SwitchCameraButton" Text="Switch Camera" BackgroundColor="Brown" TextColor="White" Clicked="SwitchCameraButton_Clicked" HorizontalOptions="EndAndExpand"
-                        CornerRadius="0"/>
+        <StackLayout Orientation="Horizontal" 
+                     Grid.Row="0">
+            <Button Text="Cancel" 
+                    BackgroundColor="#FF0000" 
+                    TextColor="White"
+                    Clicked="CancelButton_Clicked"
+                    HorizontalOptions="StartAndExpand"
+                    CornerRadius="0"/>
+            <Button Text="Flashlight"
+                    BackgroundColor="#0075FF"
+                    TextColor="White"
+                    Clicked="FlashlightButton_Clicked"
+                    HorizontalOptions="CenterAndExpand"
+                    CornerRadius="0"/>
+
+            <Button Text="Switch Camera"
+                    BackgroundColor="Brown"
+                    TextColor="White"
+                    Clicked="SwitchCameraButton_Clicked" 
+                    HorizontalOptions="EndAndExpand"
+                    CornerRadius="0"/>
         </StackLayout>
         <!--Fill the screen with CameraView-->
-        <gv:CameraView HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand" OnDetected="CameraView_OnDetected" Grid.Row="1"
-                           TorchOn="False" VibrationOnDetected="False" ScanInterval="50" x:Name="Camera"/>
+        <gv:CameraView OnDetected="CameraView_OnDetected" 
+                       Grid.Row="1"
+                       TorchOn="False" 
+                       VibrationOnDetected="False" 
+                       ScanInterval="50" x:Name="Camera"/>
 
         <!--IgnorePixelScaling: Make sure it is set to true. Ensures density is properly calculated-->
         <!--<skia:SKCanvasView
@@ -33,7 +50,10 @@
 
         <!--Customized Size-->
         <!--<gv:CameraView HorizontalOptions="Center" WidthRequest="200" HeightRequest="200" OnDetected="CameraView_OnDetected" Grid.Row="1"/>-->
-        <Label Text="Scan QRCode" FontSize="Medium" HorizontalOptions="FillAndExpand" HorizontalTextAlignment="Center" Grid.Row="2"
-                   TextColor="Red"/>
+        <Label Text="Scan QRCode"
+               FontSize="Medium" 
+               HorizontalTextAlignment="Center" 
+               Grid.Row="2"
+               TextColor="Red"/>
     </Grid>
 </ContentPage>

--- a/SampleApp.Maui/Page2.xaml
+++ b/SampleApp.Maui/Page2.xaml
@@ -57,8 +57,6 @@
                     Grid.Row="1"
                     Grid.Column="1"
                     OnDetected="CameraView_OnDetected"
-                    PreviewHeight="200"
-                    PreviewWidth="300"
                     TorchOn="True"
                     VibrationOnDetected="True" />
             </Grid>

--- a/SampleApp.Maui/SampleApp.Maui.csproj
+++ b/SampleApp.Maui/SampleApp.Maui.csproj
@@ -17,6 +17,9 @@
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
 
+
+		<EnableSourceControlManagerQueries>true</EnableSourceControlManagerQueries>
+
 		<!-- Display name -->
 		<ApplicationTitle>SampleApp.Maui</ApplicationTitle>
 
@@ -55,6 +58,8 @@
 	<ItemGroup>
 	  <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 	  <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
+	  <PackageReference Include="Xamarin.AndroidX.Collection" Version="1.3.0.2" />
+	  <PackageReference Include="Xamarin.AndroidX.Preference" Version="1.2.1.3" />
 	</ItemGroup>
 
 


### PR DESCRIPTION
Updated CameraX Nuget packages for MAUI to the latest and used ResolutionSelector for picking the correct resolution.

Removed `PreviewWidth` and `PreviewHeight` since Preview now is missing `UpdateSuggestedResolution` method.