### PR TITLE
Full Zoom functionality (Xamarin/MAUI) (Android/iOS)

### DIFF
--- a/BarcodeScanner.Mobile.Maui/Platforms/Android/CameraViewHandler.android.cs
+++ b/BarcodeScanner.Mobile.Maui/Platforms/Android/CameraViewHandler.android.cs
@@ -163,6 +163,14 @@ namespace BarcodeScanner.Mobile
             _camera.CameraControl.EnableTorch(VirtualView.TorchOn);
         }
 
+        private void HandleZoom()
+        {
+            if (_camera == null)
+                return;
+
+            _camera.CameraControl.SetLinearZoom(VirtualView.Zoom);
+        }
+
         private void DisableTorchIfNeeded()
         {
             if (_camera == null || !_camera.CameraInfo.HasFlashUnit || (int)_camera.CameraInfo.TorchState?.Value != TorchState.On)

--- a/BarcodeScanner.Mobile.Maui/Shared/CameraView.cs
+++ b/BarcodeScanner.Mobile.Maui/Shared/CameraView.cs
@@ -154,6 +154,22 @@ namespace BarcodeScanner.Mobile
             set => SetValue(CaptureQualityProperty, value);
         }
 
+        public static BindableProperty ZoomProperty = BindableProperty.Create(nameof(Zoom)
+           , typeof(float)
+           , typeof(CameraView)
+           , 0f
+           , defaultBindingMode: BindingMode.TwoWay
+           , propertyChanged: (bindable, value, newValue) => ((CameraView)bindable).Zoom = (float)newValue);
+
+        /// <summary>
+        /// Set the zoom level for the image.
+        /// </summary>
+        public float Zoom
+        {
+            get => (float)GetValue(ZoomProperty);
+            set => SetValue(ZoomProperty, value);
+        }
+
         public event EventHandler<OnDetectedEventArg> OnDetected;
         public void TriggerOnDetected(List<BarcodeResult> barCodeResults, byte[] imageData)
         {

--- a/BarcodeScanner.Mobile.Maui/Shared/CameraViewHandler.cs
+++ b/BarcodeScanner.Mobile.Maui/Shared/CameraViewHandler.cs
@@ -17,6 +17,7 @@ namespace BarcodeScanner.Mobile
         public static PropertyMapper<ICameraView, CameraViewHandler> CameraViewMapper = new()
         {
             [nameof(ICameraView.TorchOn)] = (handler, virtualView) => handler.HandleTorch(),
+            [nameof(ICameraView.Zoom)] = (handler, virtualView) => handler.HandleZoom(),
 #if ANDROID
             [nameof(ICameraView.CameraFacing)] = (handler, virtualView) => handler.CameraCallback(),
             [nameof(ICameraView.CaptureQuality)] = (handler, virtualView) => handler.CameraCallback()

--- a/BarcodeScanner.Mobile.Maui/Shared/ICameraView.cs
+++ b/BarcodeScanner.Mobile.Maui/Shared/ICameraView.cs
@@ -46,6 +46,7 @@ namespace BarcodeScanner.Mobile
         /// Default value is Back Camera
         /// </summary>
         public CameraFacing CameraFacing { get; set; }
+
         public static BindableProperty CaptureQualityProperty { get; set; }
         /// <summary>
         /// Set the capture quality for the image analysys.
@@ -53,6 +54,12 @@ namespace BarcodeScanner.Mobile
         /// Use highest values for more precision or lower for fast scanning.
         /// </summary>
         public CaptureQuality CaptureQuality { get; set; }
+
+        public static BindableProperty ZoomProperty { get; set; }
+        /// <summary>
+        /// Set the zoom level for the image.
+        /// </summary>
+        public float Zoom { get; set; }
 
         public event EventHandler<OnDetectedEventArg> OnDetected;
         public void TriggerOnDetected(List<BarcodeResult> barCodeResults, byte[] imageData);

--- a/BarcodeScanner.Mobile.XamarinForms/iOS/Renderer/CameraViewRenderer.cs
+++ b/BarcodeScanner.Mobile.XamarinForms/iOS/Renderer/CameraViewRenderer.cs
@@ -14,7 +14,7 @@ namespace BarcodeScanner.Mobile.Renderer
         protected override void OnElementChanged(ElementChangedEventArgs<CameraView> e)
         {
             if (Runtime.Arch == Arch.SIMULATOR) return;
-            
+
             base.OnElementChanged(e);
             if (e.OldElement != null || Element == null)
             {
@@ -38,7 +38,7 @@ namespace BarcodeScanner.Mobile.Renderer
         protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             if (Runtime.Arch == Arch.SIMULATOR) return;
-            
+
             base.OnElementPropertyChanged(sender, e);
             if (e.PropertyName == CameraView.TorchOnProperty.PropertyName)
             {
@@ -51,6 +51,10 @@ namespace BarcodeScanner.Mobile.Renderer
             else if (e.PropertyName == CameraView.CaptureQualityProperty.PropertyName)
             {
                 liveCameraStream.ChangeSessionPreset(Element.CaptureQuality);
+            }
+            else if (e.PropertyName == CameraView.ZoomProperty.PropertyName)
+            {
+                liveCameraStream.SetZoom(Element.Zoom);
             }
         }
 

--- a/SampleApp.Maui/SampleApp.Maui.csproj
+++ b/SampleApp.Maui/SampleApp.Maui.csproj
@@ -40,10 +40,10 @@
 
 
 		<!-- App Icon -->
-		<AndroidResource Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#512BD4" />
+		<MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#512BD4" />
 
 		<!-- Splash Screen -->
-		<AndroidResource Include="Resources\Splash\splash.svg" Color="#512BD4" BaseSize="128,128" />
+		<MauiSplashScreen Include="Resources\Splash\splash.svg" Color="#512BD4" BaseSize="128,128" />
 
 		<!-- Images -->
 		<MauiImage Include="Resources\Images\*" />
@@ -56,15 +56,6 @@
 		<MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
 	</ItemGroup>
 
-	<ItemGroup>
-	  <MauiFont Remove="Resources\Fonts\OpenSans-Regular.ttf" />
-	  <MauiFont Remove="Resources\Fonts\OpenSans-Semibold.ttf" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <AndroidResource Include="Resources\Fonts\OpenSans-Regular.ttf" />
-	  <AndroidResource Include="Resources\Fonts\OpenSans-Semibold.ttf" />
-	</ItemGroup>
 	<ItemGroup>
 	  <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 	  <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />

--- a/SampleApp.Maui/SampleApp.Maui.csproj
+++ b/SampleApp.Maui/SampleApp.Maui.csproj
@@ -40,10 +40,10 @@
 
 
 		<!-- App Icon -->
-		<MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#512BD4" />
+		<AndroidResource Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#512BD4" />
 
 		<!-- Splash Screen -->
-		<MauiSplashScreen Include="Resources\Splash\splash.svg" Color="#512BD4" BaseSize="128,128" />
+		<AndroidResource Include="Resources\Splash\splash.svg" Color="#512BD4" BaseSize="128,128" />
 
 		<!-- Images -->
 		<MauiImage Include="Resources\Images\*" />
@@ -54,6 +54,16 @@
 
 		<!-- Raw Assets (also remove the "Resources\Raw" prefix) -->
 		<MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <MauiFont Remove="Resources\Fonts\OpenSans-Regular.ttf" />
+	  <MauiFont Remove="Resources\Fonts\OpenSans-Semibold.ttf" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <AndroidResource Include="Resources\Fonts\OpenSans-Regular.ttf" />
+	  <AndroidResource Include="Resources\Fonts\OpenSans-Semibold.ttf" />
 	</ItemGroup>
 	<ItemGroup>
 	  <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />

--- a/SampleApp.XF/SampleApp.XF/Mvvm/MvvmDemo.xaml
+++ b/SampleApp.XF/SampleApp.XF/Mvvm/MvvmDemo.xaml
@@ -14,6 +14,7 @@
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="*"/>
                 <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="30"/>
@@ -64,12 +65,22 @@
                            OnDetectedCommand="{Binding OnDetectCommand}" 
                            IsScanning="{Binding IsScanning}" 
                            TorchOn="{Binding TorchOn}" VibrationOnDetected="{Binding VibrationOnDetected}" ScanInterval="{Binding ScanInterval}"
-                           x:Name="Camera" HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand"/>
+                           x:Name="Camera" HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand" Zoom="{Binding Zoom}"/>
             <!--Customized Size-->
             <!--<gv:CameraView HorizontalOptions="Center" WidthRequest="200" HeightRequest="200" OnDetected="CameraView_OnDetected" Grid.Row="1"/>-->
             <StackLayout Grid.Row="2" HeightRequest="120" Grid.ColumnSpan="3">
                 <Label Text="Result" TextColor="Red"></Label>
                 <Label Text="{Binding Result}" TextColor="Black"></Label>
+            </StackLayout>
+
+            <StackLayout Grid.Row="3" Grid.ColumnSpan="3">
+                <Label Text="Zoom" TextColor="White" />
+                <Slider
+                    x:Name="ZoomSlider"
+                    HeightRequest="50"
+                    Value="{Binding Zoom}"
+                    Maximum="1"
+                    Minimum="0" />
             </StackLayout>
         </Grid>
     </ContentPage.Content>

--- a/SampleApp.XF/SampleApp.XF/Mvvm/MvvmDemoViewModel.cs
+++ b/SampleApp.XF/SampleApp.XF/Mvvm/MvvmDemoViewModel.cs
@@ -111,6 +111,17 @@ namespace SampleApp.XF.Mvvm
             }
         }
 
+        private float _zoom { get; set; }
+        public float Zoom
+        {
+            get { return _zoom; }
+            set
+            {
+                _zoom = value;
+                OnPropertyChanged(nameof(Zoom));
+            }
+        }
+
         public MvvmDemoViewModel()
         {
             this.TorchOn = true;

--- a/SampleApp.XF/SampleApp.XF/Page1.xaml
+++ b/SampleApp.XF/SampleApp.XF/Page1.xaml
@@ -13,6 +13,7 @@
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="*"/>
                 <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
             <StackLayout Orientation="Horizontal" HorizontalOptions="FillAndExpand" Grid.Row="0">
                 <Button x:Name="CancelButton" Text="Cancel" BackgroundColor="#FF0000" TextColor="White" Clicked="CancelButton_Clicked" HorizontalOptions="StartAndExpand"
@@ -24,7 +25,7 @@
             </StackLayout>
             <!--Fill the screen with CameraView-->
             <gv:CameraView HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand" OnDetected="CameraView_OnDetected" Grid.Row="1"
-                           TorchOn="False" VibrationOnDetected="False" ScanInterval="50" x:Name="Camera"/>
+                           TorchOn="False" VibrationOnDetected="False" ScanInterval="50" x:Name="Camera" Zoom="{Binding Source={Reference ZoomSlider}, Path=Value}"/>
 
             <!--IgnorePixelScaling: Make sure it is set to true. Ensures density is properly calculated-->
             <!--<skia:SKCanvasView
@@ -39,6 +40,15 @@
             <!--<gv:CameraView HorizontalOptions="Center" WidthRequest="200" HeightRequest="200" OnDetected="CameraView_OnDetected" Grid.Row="1"/>-->
             <Label Text="Scan QRCode" FontSize="Medium" HorizontalOptions="FillAndExpand" HorizontalTextAlignment="Center" Grid.Row="2"
                    TextColor="Red"/>
+
+            <StackLayout Grid.Row="3">
+                <Label Text="Zoom" TextColor="White" />
+                <Slider
+                    x:Name="ZoomSlider"
+                    HeightRequest="50"
+                    Maximum="1"
+                    Minimum="0" />
+            </StackLayout>
         </Grid>
      
     </ContentPage.Content>

--- a/SampleApp.XF/SampleApp.XF/Page2.xaml
+++ b/SampleApp.XF/SampleApp.XF/Page2.xaml
@@ -13,6 +13,7 @@
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
                 <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
             <StackLayout
                 Grid.Row="0"
@@ -25,8 +26,7 @@
                     CornerRadius="0"
                     HorizontalOptions="StartAndExpand"
                     Text="Cancel"
-                    TextColor="White"
-                    />
+                    TextColor="White" />
                 <Button
                     x:Name="FlashlightButton"
                     BackgroundColor="#0075FF"
@@ -34,8 +34,7 @@
                     CornerRadius="0"
                     HorizontalOptions="CenterAndExpand"
                     Text="Flashlight"
-                    TextColor="White"
-                    />
+                    TextColor="White" />
 
                 <Button
                     x:Name="SwitchCameraButton"
@@ -44,8 +43,7 @@
                     CornerRadius="0"
                     HorizontalOptions="EndAndExpand"
                     Text="Switch Camera"
-                    TextColor="White"
-                    />
+                    TextColor="White" />
 
             </StackLayout>
             <!--  Fill the screen with CameraView  -->
@@ -63,7 +61,8 @@
                     PreviewHeight="200"
                     PreviewWidth="300"
                     TorchOn="True"
-                    VibrationOnDetected="True" />
+                    VibrationOnDetected="True"
+                    Zoom="{Binding Source={Reference ZoomSlider}, Path=Value}" />
             </Grid>
             <Label
                 Grid.Row="2"
@@ -72,6 +71,15 @@
                 HorizontalTextAlignment="Center"
                 Text="Scan QRCode"
                 TextColor="Red" />
+
+            <StackLayout Grid.Row="3">
+                <Label Text="Zoom" TextColor="White" />
+                <Slider
+                    x:Name="ZoomSlider"
+                    HeightRequest="50"
+                    Maximum="1"
+                    Minimum="0" />
+            </StackLayout>
         </Grid>
 
     </ContentPage.Content>

--- a/SampleApp.XF/SampleApp.XF/Page3.xaml
+++ b/SampleApp.XF/SampleApp.XF/Page3.xaml
@@ -13,6 +13,7 @@
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="*"/>
                 <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
             <ScrollView Grid.Row="0" Orientation="Horizontal">
             <StackLayout Orientation="Horizontal" HorizontalOptions="FillAndExpand">
@@ -28,11 +29,20 @@
             </ScrollView>
             <!--Fill the screen with CameraView-->
             <gv:CameraView HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand" OnDetected="CameraView_OnDetected" Grid.Row="1"
-                           TorchOn="True" VibrationOnDetected="True" IsScanning="False" CaptureQuality="High" x:Name="Camera"/>
+                           TorchOn="True" VibrationOnDetected="True" IsScanning="False" CaptureQuality="High" x:Name="Camera" Zoom="{Binding Source={Reference ZoomSlider}, Path=Value}"/>
             <!--Customized Size-->
             <!--<gv:CameraView HorizontalOptions="Center" WidthRequest="200" HeightRequest="200" OnDetected="CameraView_OnDetected" Grid.Row="1"/>-->
             <Label Text="Scan QRCode" FontSize="Medium" HorizontalOptions="FillAndExpand" HorizontalTextAlignment="Center" Grid.Row="2"
                    TextColor="Red"/>
+
+            <StackLayout Grid.Row="3">
+                <Label Text="Zoom" TextColor="White" />
+                <Slider
+                    x:Name="ZoomSlider"
+                    HeightRequest="50"
+                    Maximum="1"
+                    Minimum="0" />
+            </StackLayout>
         </Grid>
 
     </ContentPage.Content>

--- a/SampleApp.XF/SampleApp.XF/Page4.xaml
+++ b/SampleApp.XF/SampleApp.XF/Page4.xaml
@@ -8,6 +8,7 @@
             <RowDefinition Height="100"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         <FlexLayout Grid.Row="0" Wrap="Wrap" Direction="Row" JustifyContent="SpaceEvenly" AlignItems="Center">
             <Button Text="Cancel" BackgroundColor="#FF0000" TextColor="White" Clicked="CancelButton_Clicked" />
@@ -18,10 +19,19 @@
         </FlexLayout>
         <!--Fill the screen with CameraView-->
         <gv:CameraView OnDetected="CameraView_OnDetected" Grid.Row="1"
-                       TorchOn="True" VibrationOnDetected="True" IsScanning="False" x:Name="Camera"/>
+                       TorchOn="True" VibrationOnDetected="True" IsScanning="False" x:Name="Camera" Zoom="{Binding Source={Reference ZoomSlider}, Path=Value}"/>
         <!--Customized Size-->
         <!--<gv:CameraView HorizontalOptions="Center" WidthRequest="200" HeightRequest="200" OnDetected="CameraView_OnDetected" Grid.Row="1"/>-->
         <Label Text="Scan QRCode" FontSize="Medium" HorizontalOptions="FillAndExpand" HorizontalTextAlignment="Center" Grid.Row="2"
                TextColor="Red"/>
+
+        <StackLayout Grid.Row="3">
+            <Label Text="Zoom" TextColor="White" />
+            <Slider
+                    x:Name="ZoomSlider"
+                    HeightRequest="50"
+                    Maximum="1"
+                    Minimum="0" />
+        </StackLayout>
     </Grid>
 </ContentPage>


### PR DESCRIPTION
Added zoom functionality for Xamarin.iOS and .NET MAUI Android & iOS.

In Xamarin.Android was used the SetLinearZoom() which accepts values from 0.0 - 1.0 and the CameraView control implementation for zoom was made with a default value 0 to support that value range. I did not want to make breaking changes, since users' apps that have already used the zoom feature for Android would crash when running on iOS cause iOS native zoom setter accepts minimum value 1.0, so I implemented a translator in iOS to support those values, but we should consider to change to SetZoomRatio() in Android which accepts values and behaves same as iOS.