### PR TITLE
MLKit switch to AdamE backend, Update AndroidX references to latest

### DIFF
--- a/BarcodeScanner.Mobile.Maui/BarcodeScanner.Mobile.Maui.csproj
+++ b/BarcodeScanner.Mobile.Maui/BarcodeScanner.Mobile.Maui.csproj
@@ -5,13 +5,11 @@
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
 		<!-- <TargetFrameworks>$(TargetFrameworks);net6.0-tizen</TargetFrameworks> -->
 		<UseMaui>true</UseMaui>
-		<MauiVersion>8.0.21</MauiVersion>
+		<MauiVersion>8.0.40</MauiVersion>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
-
-
 
 		<!--Assembly and Namespace info -->
 		<id>BarcodeScanner.Mobile.Maui</id>
@@ -19,9 +17,9 @@
 		<RootNamespace>BarcodeScanner.Mobile.Maui</RootNamespace>
 
 		<Product></Product>
-		<AssemblyVersion>8.0.21</AssemblyVersion>
-		<AssemblyFileVersion>8.0.21</AssemblyFileVersion>
-		<Version>8.0.21</Version>
+		<AssemblyVersion>8.0.40</AssemblyVersion>
+		<AssemblyFileVersion>8.0.40</AssemblyFileVersion>
+		<Version>8.0.40</Version>
 		<NeutralLanguage>en</NeutralLanguage>
 
 		<!--Version of C# to use -->
@@ -29,27 +27,31 @@
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<Authors>Jimmy Pun, Anton Yaroshenko</Authors>
 		<Description>Powerful MAUI barcode scanning library using GoogleVision API for Android and iOS.</Description>
-		<PackageIconUrl>https://banner2.kisspng.com/20180713/olo/kisspng-nuget-net-framework-package-manager-software-repo-nuget-5b487dc3ba81a7.452233091531477443764.jpg</PackageIconUrl>
 		<RepositoryUrl>https://github.com/JimmyPun610/BarcodeScanner.Mobile</RepositoryUrl>
 		<PackageProjectUrl>https://github.com/JimmyPun610/BarcodeScanner.Mobile</PackageProjectUrl>
-		<PackageLicenseUrl>https://github.com/JimmyPun610/BarcodeScanner.Mobile</PackageLicenseUrl>
+		<PackageLicense>https://github.com/JimmyPun610/BarcodeScanner.Mobile</PackageLicense>
 		<RepositoryType></RepositoryType>
 		<PackageTags>MAUI Barcode Scanning Tools</PackageTags>
-		<PackageReleaseNotes>1. Merged pull request #213, #216 </PackageReleaseNotes>
+		<PackageReleaseNotes></PackageReleaseNotes>
 		<Copyright>Copyright 2023</Copyright>
 		<PackOnBuild>true</PackOnBuild>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<PackageVersion>8.0.40-alpha1</PackageVersion>
 	</PropertyGroup>
-
 
 	<!-- Going to use latest version library in MAUI -->
 	<ItemGroup Condition="( '$(TargetFramework)' == 'net8.0-android' )">
-		<PackageReference Include="Xamarin.AndroidX.Camera.Camera2" Version="1.3.0.1">
+		<PackageReference Include="Xamarin.AndroidX.Collection" Version="1.4.0.4" />
+		<PackageReference Include="Xamarin.AndroidX.Collection.Jvm" Version="1.4.0.3" />
+		<PackageReference Include="Xamarin.AndroidX.Collection.Ktx" Version="1.4.0.3" />
+		<PackageReference Include="Xamarin.AndroidX.Camera.Camera2" Version="1.3.3.2">
 		</PackageReference>
-		<PackageReference Include="Xamarin.AndroidX.Camera.Lifecycle" Version="1.3.0.1">
+		<PackageReference Include="Xamarin.AndroidX.Camera.Lifecycle" Version="1.3.3.2">
 		</PackageReference>
-		<PackageReference Include="Xamarin.AndroidX.Camera.View" Version="1.3.0.1">
+		<PackageReference Include="Xamarin.AndroidX.Camera.View" Version="1.3.3.2">
 		</PackageReference>
+        <PackageReference Include="Xamarin.Google.MLKit.Common" Version="118.10.0.2" />
+		<PackageReference Include="Xamarin.Google.MLKit.Vision.Common" Version="117.3.0.8" />
 		<PackageReference Include="Xamarin.Google.MLKit.BarcodeScanning" Version="117.2.0.4">
 		</PackageReference>
 		<PackageReference Include="Xamarin.GooglePlayServices.MLKit.Text.Recognition" Version="119.0.0.6">			
@@ -57,13 +59,9 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="( '$(TargetFramework)' == 'net8.0-ios' )">
-		<PackageReference Include="System.Numerics.Vectors" Version="4.5.0">
-		</PackageReference>
-		<PackageReference Include="Xamarin.MLKit.iOS.BarcodeScanning.JimmyPun610" Version="2.2.0.1">
-		</PackageReference>
-		<PackageReference Include="Xamarin.MLKit.iOS.Core.JimmyPun610" Version="8.0.0" />
+		<PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
+		<PackageReference Include="AdamE.MLKit.iOS.BarcodeScanning" Version="5.0.0-alpha2" />
 		<BundleResource Include="Platforms\iOS\PrivacyInfo.xcprivacy" LogicalName="PrivacyInfo.xcprivacy" />
-
 	</ItemGroup>
 	<ItemGroup>
 		<!-- We will compile anything ending in .shared.cs  You can change this -->
@@ -83,13 +81,11 @@
 	  <Compile Update="Platforms\Android\TorchStateObserver.cs">
 	    <ExcludeFromCurrentConfiguration>false</ExcludeFromCurrentConfiguration>
 	  </Compile>
-		<None Include="..\README.md" Pack="true" PackagePath="\"/>
+		<None Include="..\README.md" Pack="true" PackagePath="\" />
 	</ItemGroup>
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
 	</ItemGroup>
-
-
 </Project>

--- a/BarcodeScanner.Mobile.Maui/Platforms/iOS/CameraViewHandler.ios.cs
+++ b/BarcodeScanner.Mobile.Maui/Platforms/iOS/CameraViewHandler.ios.cs
@@ -1,7 +1,10 @@
-﻿using AVFoundation;
+﻿using System.Runtime.Intrinsics.X86;
+using AVFoundation;
 using BarcodeScanner.Mobile.Platforms.iOS;
 using CoreVideo;
 using Foundation;
+using Intents;
+using Microsoft.Maui.Controls.PlatformConfiguration;
 using UIKit;
 
 namespace BarcodeScanner.Mobile
@@ -292,7 +295,20 @@ namespace BarcodeScanner.Mobile
                 return AVCaptureDevice.GetDefaultDevice(AVCaptureDeviceType.BuiltInDualCamera, AVMediaTypes.Video, position);
             }
 
-            return AVCaptureDevice.DevicesWithMediaType(AVMediaTypes.Video.GetConstant()).FirstOrDefault(d => d.Position == position);
+            using var session = AVCaptureDeviceDiscoverySession.Create(
+                                    new[] {
+                                        AVCaptureDeviceType.BuiltInDualCamera,
+                                        AVCaptureDeviceType.BuiltInTripleCamera,
+                                        AVCaptureDeviceType.BuiltInTrueDepthCamera,
+                                        AVCaptureDeviceType.BuiltInDualWideCamera,
+                                        AVCaptureDeviceType.BuiltInWideAngleCamera,
+                                        AVCaptureDeviceType.BuiltInUltraWideCamera,
+                                        AVCaptureDeviceType.BuiltInTelephotoCamera
+                                    },
+                                    AVMediaTypes.Video,
+                                    position);
+            
+            return session.Devices.FirstOrDefault();
         }
     }
 }

--- a/BarcodeScanner.Mobile.XamarinForms/BarcodeScanner.Mobile.XamarinForms.csproj
+++ b/BarcodeScanner.Mobile.XamarinForms/BarcodeScanner.Mobile.XamarinForms.csproj
@@ -1,6 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-7"?>
-<Project Sdk="MSBuild.Sdk.Extras/3.0.44">
-
+﻿<Project Sdk="MSBuild.Sdk.Extras/3.0.44">
 	<PropertyGroup>
 
 		<!--Update with your target such as: Xamarin.iOS10 or MonoAndroid80 or Xamarin.Mac20-->
@@ -40,6 +38,7 @@
 		<Copyright>Copyright 2023</Copyright>
 		<PackOnBuild>true</PackOnBuild>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<BuildWithMSBuildOnMono>true</BuildWithMSBuildOnMono>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -54,6 +53,7 @@
 		<PackageReference Include="Xamarin.Forms" Version="5.0.0.2662" />
 		<PackageReference Include="Xamarin.Essentials" Version="1.8.1" />
 
+		<PackageReference Include="AdamE.MLKit.iOS.BarcodeScanning" Version="5.0.0-alpha2" />
 	</ItemGroup>
 	
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) ">
@@ -67,7 +67,7 @@
 	
 		<PackageReference Include="Xamarin.AndroidX.MediaRouter" Version="1.6.0">
 		</PackageReference>
-		<PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.6.2.1">
+		<PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.7.0.1">
 		</PackageReference>
 		<PackageReference Include="Xamarin.AndroidX.Browser" Version="1.5.0.3">
 		</PackageReference>
@@ -75,15 +75,15 @@
 		</PackageReference>
 		<PackageReference Include="Xamarin.AndroidX.Palette" Version="1.0.0.20">
 		</PackageReference>
-		<PackageReference Include="Xamarin.AndroidX.Core" Version="1.12.0.3">
+		<PackageReference Include="Xamarin.AndroidX.Core" Version="1.13.0">
 		</PackageReference>
 		<PackageReference Include="Xamarin.AndroidX.RecyclerView" Version="1.3.1.1">
 		</PackageReference>
-		<PackageReference Include="Xamarin.AndroidX.Camera.Camera2" Version="1.2.3.2">
+		<PackageReference Include="Xamarin.AndroidX.Camera.Camera2" Version="1.3.3">
 		</PackageReference>
-		<PackageReference Include="Xamarin.AndroidX.Camera.Lifecycle" Version="1.2.3.2">
+		<PackageReference Include="Xamarin.AndroidX.Camera.Lifecycle" Version="1.3.3">
 		</PackageReference>
-		<PackageReference Include="Xamarin.AndroidX.Camera.View" Version="1.2.3.2">
+		<PackageReference Include="Xamarin.AndroidX.Camera.View" Version="1.3.3">
 		</PackageReference>
 		<PackageReference Include="Xamarin.Google.Dagger" Version="2.46.1.2">
 		</PackageReference>
@@ -92,7 +92,6 @@
 		<PackageReference Include="Xamarin.AndroidX.Collection" Version="1.4.0.2" />
 		<PackageReference Include="Xamarin.AndroidX.Collection.Ktx" Version="1.4.0.1" />
 		<PackageReference Include="Xamarin.AndroidX.Collection.Jvm" Version="1.4.0.1" />
-		
 	</ItemGroup>
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('Xamarin.iOS')) ">
 		<Compile Include="iOS\*.cs" />
@@ -101,12 +100,7 @@
 
 		<PackageReference Include="System.Numerics.Vectors" Version="4.5.0">
 		</PackageReference>
-		<PackageReference Include="Xamarin.MLKit.iOS.BarcodeScanning.JimmyPun610" Version="2.2.0.1">
+		<PackageReference Include="AdamE.MLKit.iOS.BarcodeScanning" Version="5.0.0-alpha2">
 		</PackageReference>
-		<PackageReference Include="Xamarin.MLKit.iOS.Core.JimmyPun610" Version="8.0.0" />
 	</ItemGroup>
-
-
-
-
 </Project>

--- a/SampleApp.Maui/SampleApp.Maui.csproj
+++ b/SampleApp.Maui/SampleApp.Maui.csproj
@@ -1,19 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<!-- Choose either one -->
-		<!-- Android Config -->
-		<TargetFrameworks>net8.0-android</TargetFrameworks>
-		<!-- iOS Config -->
-		<!--<TargetFrameworks>net7.0-ios;</TargetFrameworks>
-		<RuntimeIdentifier>ios-arm64</RuntimeIdentifier>
-		<PlatformTarget>arm64</PlatformTarget>-->
-		<!-- -->
-		<MauiVersion>8.0.3</MauiVersion>
+		<TargetFrameworks>net8.0-ios;net8.0-android</TargetFrameworks>
+		<RuntimeIdentifier Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">ios-arm64</RuntimeIdentifier>
+		<PlatformTarget>arm64</PlatformTarget>
+
+		<MauiVersion>8.0.40</MauiVersion>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>SampleApp.Maui</RootNamespace>
 		<UseMaui>true</UseMaui>
-		<MauiVersion>8.0.3</MauiVersion>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
 
@@ -24,14 +19,14 @@
 		<ApplicationTitle>SampleApp.Maui</ApplicationTitle>
 
 		<!-- App Identifier -->
-		<ApplicationId>wine.cellr.trace</ApplicationId>
+		<ApplicationId>com.barcodescanner.sampleapp.maui</ApplicationId>
 		<ApplicationIdGuid>DBFCEE53-0F1F-4206-AF27-0F8F87160EF2</ApplicationIdGuid>
 
 		<!-- Versions -->
 		<ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
 		<ApplicationVersion>1</ApplicationVersion>
 
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">10.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">12.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
 		
 	</PropertyGroup>
@@ -59,8 +54,8 @@
 	<ItemGroup>
 	  <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 	  <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
-	  <PackageReference Include="Xamarin.AndroidX.Collection" Version="1.3.0.2" />
-	  <PackageReference Include="Xamarin.AndroidX.Preference" Version="1.2.1.3" />
+	  <PackageReference Include="Xamarin.AndroidX.Activity" Version="1.9.0.2" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'" />
+	  <PackageReference Include="Xamarin.AndroidX.Activity.Ktx" Version="1.9.0.2" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'" />
 	</ItemGroup>
 
 
@@ -89,5 +84,4 @@
 	  </MauiXaml>
 
 	</ItemGroup>
-
 </Project>

--- a/SampleApp.XF/SampleApp.XF.Android/SampleApp.XF.Android.csproj
+++ b/SampleApp.XF/SampleApp.XF.Android/SampleApp.XF.Android.csproj
@@ -58,11 +58,11 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData">
-      <Version>2.6.2.1</Version>
+      <Version>2.7.0.1</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2662" />
     <PackageReference Include="Xamarin.Essentials" Version="1.8.1" />
-    <PackageReference Include="BarcodeScanner.Mobile.XamarinForms" Version="6.3.1" />
+	<ProjectReference Include="..\..\BarcodeScanner.Mobile.XamarinForms\BarcodeScanner.Mobile.XamarinForms.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />

--- a/SampleApp.XF/SampleApp.XF.iOS/SampleApp.XF.iOS.csproj
+++ b/SampleApp.XF/SampleApp.XF.iOS/SampleApp.XF.iOS.csproj
@@ -129,7 +129,7 @@
     <PackageReference Include="Xam.Plugin.Media" Version="6.0.2" />
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2662" />
     <PackageReference Include="Xamarin.Essentials" Version="1.8.1" />
-    <PackageReference Include="BarcodeScanner.Mobile.XamarinForms" Version="6.3.1" />
+    <ProjectReference Include="..\..\BarcodeScanner.Mobile.XamarinForms\BarcodeScanner.Mobile.XamarinForms.csproj" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>

--- a/SampleApp.XF/SampleApp.XF/SampleApp.XF.csproj
+++ b/SampleApp.XF/SampleApp.XF/SampleApp.XF.csproj
@@ -3,6 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+		<BuildWithMSBuildOnMono>true</BuildWithMSBuildOnMono>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -14,7 +15,6 @@
 		<PackageReference Include="Xam.Plugin.Media" Version="6.0.2" />
 		<PackageReference Include="Xamarin.Forms" Version="5.0.0.2662" />
 		<PackageReference Include="Xamarin.Essentials" Version="1.8.1" />
-		<PackageReference Include="BarcodeScanner.Mobile.XamarinForms" Version="6.3.1" />
 	</ItemGroup>
 	<ItemGroup>
 		<EmbeddedResource Update="Mvvm\MvvmDemo.xaml">
@@ -32,5 +32,8 @@
 		<EmbeddedResource Update="Page4.xaml">
 		  <Generator>MSBuild:Compile</Generator>
 		</EmbeddedResource>
+	</ItemGroup>
+	<ItemGroup>
+	  <ProjectReference Include="..\..\BarcodeScanner.Mobile.XamarinForms\BarcodeScanner.Mobile.XamarinForms.csproj" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Goal here was to switch over to the new public repo that AdamE is maintaining for the GoogleForiOSComponents repository that was abandoned by the Xamarin team.  Also updated some Android references that were causing local build errors and eliminated the 'utf-7' encoding that was preventing Visual Studio Mac from interacting with the project files.  The end result is some crazy project reformatting, sorry about that.