### PR TITLE
NET9, #99, #243, fixes for nested page back navigation, prevent infinity loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ bin
 /.vs/BarcodeScanner.Mobile/v17
 /.vs/BarcodeScanner.Mobile/project-colors.json
 /.vs/BarcodeScanner.Mobile
+/.vs/*

--- a/BarcodeScanner.Mobile.Maui.sln
+++ b/BarcodeScanner.Mobile.Maui.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.12.35707.178
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BarcodeScanner.Mobile.Maui", "BarcodeScanner.Mobile.Maui\BarcodeScanner.Mobile.Maui.csproj", "{DC50D165-EAE6-47CF-8916-6CA8876173E5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleApp.Maui", "SampleApp.Maui\SampleApp.Maui.csproj", "{9C07CD5A-0132-4147-A459-AFE8CF908FDB}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{DC50D165-EAE6-47CF-8916-6CA8876173E5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DC50D165-EAE6-47CF-8916-6CA8876173E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DC50D165-EAE6-47CF-8916-6CA8876173E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DC50D165-EAE6-47CF-8916-6CA8876173E5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9C07CD5A-0132-4147-A459-AFE8CF908FDB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9C07CD5A-0132-4147-A459-AFE8CF908FDB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9C07CD5A-0132-4147-A459-AFE8CF908FDB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9C07CD5A-0132-4147-A459-AFE8CF908FDB}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/BarcodeScanner.Mobile.Maui/BarcodeScanner.Mobile.Maui.csproj
+++ b/BarcodeScanner.Mobile.Maui/BarcodeScanner.Mobile.Maui.csproj
@@ -17,9 +17,9 @@
 		<RootNamespace>BarcodeScanner.Mobile.Maui</RootNamespace>
 
 		<Product></Product>
-		<AssemblyVersion>8.0.40.1</AssemblyVersion>
-		<AssemblyFileVersion>8.0.40.1</AssemblyFileVersion>
-		<Version>8.0.40.1</Version>
+		<AssemblyVersion>9.0.0.1</AssemblyVersion>
+		<AssemblyFileVersion>9.0.0.1</AssemblyFileVersion>
+		<Version>9.0.0.1</Version>
 		<NeutralLanguage>en</NeutralLanguage>
 
 		<!--Version of C# to use -->
@@ -36,7 +36,7 @@
 		<Copyright>Copyright 2024</Copyright>
 		<PackOnBuild>true</PackOnBuild>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<PackageVersion>8.0.40.1</PackageVersion>
+		<PackageVersion>9.0.0.1</PackageVersion>
 	</PropertyGroup>
 
 	<!-- Going to use latest version library in MAUI -->

--- a/BarcodeScanner.Mobile.Maui/BarcodeScanner.Mobile.Maui.csproj
+++ b/BarcodeScanner.Mobile.Maui/BarcodeScanner.Mobile.Maui.csproj
@@ -5,7 +5,7 @@
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
 		<!-- <TargetFrameworks>$(TargetFrameworks);net6.0-tizen</TargetFrameworks> -->
 		<UseMaui>true</UseMaui>
-		<MauiVersion>8.0.40</MauiVersion>
+		<MauiVersion>8.0.60</MauiVersion>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.0</SupportedOSPlatformVersion>

--- a/BarcodeScanner.Mobile.Maui/BarcodeScanner.Mobile.Maui.csproj
+++ b/BarcodeScanner.Mobile.Maui/BarcodeScanner.Mobile.Maui.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net8.0-android;net8.0-ios;</TargetFrameworks>
+		<TargetFrameworks>net9.0;net9.0-android;net9.0-ios;</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
 		<!-- <TargetFrameworks>$(TargetFrameworks);net6.0-tizen</TargetFrameworks> -->
 		<UseMaui>true</UseMaui>
-		<MauiVersion>8.0.60</MauiVersion>
+		<MauiVersion>9.0.30</MauiVersion>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.0</SupportedOSPlatformVersion>
@@ -40,27 +40,27 @@
 	</PropertyGroup>
 
 	<!-- Going to use latest version library in MAUI -->
-	<ItemGroup Condition="( '$(TargetFramework)' == 'net8.0-android' )">
-		<PackageReference Include="Xamarin.AndroidX.Collection" Version="1.4.0.4" />
-		<PackageReference Include="Xamarin.AndroidX.Collection.Jvm" Version="1.4.0.3" />
-		<PackageReference Include="Xamarin.AndroidX.Collection.Ktx" Version="1.4.0.3" />
-		<PackageReference Include="Xamarin.AndroidX.Camera.Camera2" Version="1.3.3.2">
+	<ItemGroup Condition="( '$(TargetFramework)' == 'net9.0-android' )">
+		<PackageReference Include="Xamarin.AndroidX.Collection" Version="1.4.5.2" />
+		<PackageReference Include="Xamarin.AndroidX.Collection.Jvm" Version="1.4.5.2" />
+		<PackageReference Include="Xamarin.AndroidX.Collection.Ktx" Version="1.4.5.2" />
+		<PackageReference Include="Xamarin.AndroidX.Camera.Camera2" Version="1.4.1.1">
 		</PackageReference>
-		<PackageReference Include="Xamarin.AndroidX.Camera.Lifecycle" Version="1.3.3.2">
+		<PackageReference Include="Xamarin.AndroidX.Camera.Lifecycle" Version="1.4.1.1">
 		</PackageReference>
-		<PackageReference Include="Xamarin.AndroidX.Camera.View" Version="1.3.3.2">
+		<PackageReference Include="Xamarin.AndroidX.Camera.View" Version="1.4.1.1">
 		</PackageReference>
-        <PackageReference Include="Xamarin.Google.MLKit.Common" Version="118.10.0.2" />
-		<PackageReference Include="Xamarin.Google.MLKit.Vision.Common" Version="117.3.0.8" />
-		<PackageReference Include="Xamarin.Google.MLKit.BarcodeScanning" Version="117.2.0.4">
+        <PackageReference Include="Xamarin.Google.MLKit.Common" Version="118.11.0.2" />
+		<PackageReference Include="Xamarin.Google.MLKit.Vision.Common" Version="117.3.0.13" />
+		<PackageReference Include="Xamarin.Google.MLKit.BarcodeScanning" Version="117.3.0.2">
 		</PackageReference>
-		<PackageReference Include="Xamarin.GooglePlayServices.MLKit.Text.Recognition" Version="119.0.0.6">			
+		<PackageReference Include="Xamarin.GooglePlayServices.MLKit.Text.Recognition" Version="119.0.1.2">			
 		</PackageReference>
 	</ItemGroup>
 
-	<ItemGroup Condition="( '$(TargetFramework)' == 'net8.0-ios' )">
-		<PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
-		<PackageReference Include="AdamE.MLKit.iOS.BarcodeScanning" Version="5.0.0-alpha2" />
+	<ItemGroup Condition="( '$(TargetFramework)' == 'net9.0-ios' )">
+		<PackageReference Include="System.Numerics.Vectors" Version="4.6.0" />
+		<PackageReference Include="AdamE.MLKit.iOS.BarcodeScanning" Version="6.0.0" />
 		<BundleResource Include="Platforms\iOS\PrivacyInfo.xcprivacy" LogicalName="PrivacyInfo.xcprivacy" />
 	</ItemGroup>
 	<ItemGroup>

--- a/BarcodeScanner.Mobile.Maui/Platforms/Android/BarcodeAnalyzer.cs
+++ b/BarcodeScanner.Mobile.Maui/Platforms/Android/BarcodeAnalyzer.cs
@@ -16,10 +16,12 @@ namespace BarcodeScanner.Mobile
         private readonly ICameraView _cameraView;
         private long _lastRunTime = DateTimeOffset.Now.ToUnixTimeMilliseconds();
         private long _lastAnalysisTime = DateTimeOffset.MinValue.ToUnixTimeMilliseconds();
+        private Action _barcodeDisposed;
 
 
-        public BarcodeAnalyzer(ICameraView cameraView)
+        public BarcodeAnalyzer(ICameraView cameraView, Action barcodeDisposed)
         {
+            _barcodeDisposed = barcodeDisposed;
             _cameraView = cameraView;
             if (_cameraView != null && _cameraView.ScanInterval < 100)
                 _cameraView.ScanInterval = 500;
@@ -130,6 +132,7 @@ namespace BarcodeScanner.Mobile
             catch (ArgumentException)
             {
                 //Ignore argument exception, it will be thrown if BarcodeAnalyzer get disposed during processing
+                _barcodeDisposed?.Invoke();
             }
         }
 

--- a/BarcodeScanner.Mobile.Maui/Platforms/Android/CameraViewHandler.android.cs
+++ b/BarcodeScanner.Mobile.Maui/Platforms/Android/CameraViewHandler.android.cs
@@ -128,7 +128,7 @@ namespace BarcodeScanner.Mobile
         {
             _isAutofocusRunning = true;
 
-            while (!_isDisposed && _previewView != null)
+            while (!_isDisposed)
             {
 
                 await Task.Delay(Configuration.AutofocusInterval);
@@ -156,7 +156,7 @@ namespace BarcodeScanner.Mobile
                     }
                     catch (Exception e)
                     {
-                        Log.Debug($"{nameof(CameraViewHandler)}-{nameof(HandleAutoFocus)}", e.ToString());
+                        Log.Warn($"{nameof(CameraViewHandler)}-{nameof(HandleAutoFocus)}", e.ToString());
                     }
                 });
             }
@@ -229,7 +229,7 @@ namespace BarcodeScanner.Mobile
             }
             catch (Exception ex)
             {
-                Log.Debug($"{nameof(CameraViewHandler)}-{nameof(ClearCameraProvider)}", ex.ToString());
+                Log.Warn($"{nameof(CameraViewHandler)}-{nameof(ClearCameraProvider)}", ex.ToString());
             }
         }
     }

--- a/BarcodeScanner.Mobile.Maui/Platforms/Android/CameraViewHandler.android.cs
+++ b/BarcodeScanner.Mobile.Maui/Platforms/Android/CameraViewHandler.android.cs
@@ -75,7 +75,7 @@ namespace BarcodeScanner.Mobile
                                 .Build();
 
 
-            imageAnalyzer.SetAnalyzer(_cameraExecutor, new BarcodeAnalyzer(VirtualView, () => MainThread.BeginInvokeOnMainThread(() => CameraCallback())));
+            imageAnalyzer.SetAnalyzer(_cameraExecutor, new BarcodeAnalyzer(VirtualView, () => MainThread.BeginInvokeOnMainThread(CameraCallback)));
 
             var cameraSelector = SelectCamera(cameraProvider);
 

--- a/BarcodeScanner.Mobile.Maui/Platforms/Android/Configuration.cs
+++ b/BarcodeScanner.Mobile.Maui/Platforms/Android/Configuration.cs
@@ -5,5 +5,9 @@ namespace BarcodeScanner.Mobile
     public static class Configuration
     {
         public static int BarcodeFormats = Barcode.FormatAllFormats;
+        /// <summary>
+        /// In milliseconds, Default is 3000ms
+        /// </summary>
+        public static int AutofocusInterval = 3000;
     }
 }

--- a/BarcodeScanner.Mobile.Maui/Platforms/Android/Methods.cs
+++ b/BarcodeScanner.Mobile.Maui/Platforms/Android/Methods.cs
@@ -11,8 +11,6 @@ namespace BarcodeScanner.Mobile
     // All the code in this file is only included on Android.
     public class Methods
     {
-       
-
         internal static BarcodeTypes ConvertBarcodeResultTypes(int barcodeValueType)
         {
             switch (barcodeValueType)
@@ -82,6 +80,8 @@ namespace BarcodeScanner.Mobile
             return formats;
         }
         #region Public Methods
+
+        public static void SetAutofocusInterval(int interval) => Configuration.AutofocusInterval = interval;
 
         public static void SetSupportBarcodeFormat(BarcodeFormats barcodeFormats)
         {

--- a/BarcodeScanner.Mobile.Maui/Platforms/iOS/CameraViewHandler.ios.cs
+++ b/BarcodeScanner.Mobile.Maui/Platforms/iOS/CameraViewHandler.ios.cs
@@ -1,11 +1,7 @@
-﻿using System.Runtime.Intrinsics.X86;
-using AVFoundation;
+﻿using AVFoundation;
 using BarcodeScanner.Mobile.Platforms.iOS;
 using CoreVideo;
 using Foundation;
-using Intents;
-using Microsoft.Maui.Controls.PlatformConfiguration;
-using UIKit;
 
 namespace BarcodeScanner.Mobile
 {
@@ -307,7 +303,7 @@ namespace BarcodeScanner.Mobile
                                     },
                                     AVMediaTypes.Video,
                                     position);
-            
+
             return session.Devices.FirstOrDefault();
         }
     }

--- a/BarcodeScanner.Mobile.Maui/Shared/CameraView.cs
+++ b/BarcodeScanner.Mobile.Maui/Shared/CameraView.cs
@@ -189,20 +189,5 @@ namespace BarcodeScanner.Mobile
                 OnDetectedCommand?.Execute(new OnDetectedEventArg { OCRResult = ocrResult, BarcodeResults = barCodeResults, ImageData = imageData });
             });
         }
-
-        public CameraView()
-        {
-            this.Unloaded += CameraView_Unloaded;
-        }
-        /// <summary>
-        /// Due to DisconnectHandler has to be called manually...we do it when the Window unloaded
-        /// https://github.com/dotnet/maui/issues/3604
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void CameraView_Unloaded(object sender, EventArgs e)
-        {
-            Handler?.DisconnectHandler();
-        }
     }
 }

--- a/BarcodeScanner.Mobile.Maui/Shared/CameraViewHandler.cs
+++ b/BarcodeScanner.Mobile.Maui/Shared/CameraViewHandler.cs
@@ -27,9 +27,6 @@ namespace BarcodeScanner.Mobile
 #endif
         };
 
-        public static CommandMapper<ICameraView, CameraViewHandler> CameraCommandMapper = new()
-        {
-        };
 
         public CameraViewHandler() : base(CameraViewMapper)
         {
@@ -42,13 +39,27 @@ namespace BarcodeScanner.Mobile
 
         protected override void ConnectHandler(NativeCameraView nativeView)
         {
+            if (VirtualView is View view)
+            {
+                view.Loaded += ViewOnLoaded;
+                view.Unloaded += ViewOnUnloaded;
+            }
             base.ConnectHandler(nativeView);
-            this.Connect();
         }
+
+        private void ViewOnUnloaded(object sender, EventArgs e) => Dispose();
+        private void ViewOnLoaded(object sender, EventArgs e) => Connect();
 
         protected override void DisconnectHandler(NativeCameraView platformView)
         {
-            this.Dispose();
+            if (VirtualView is View view)
+            {
+                view.Loaded -= ViewOnLoaded;
+                view.Unloaded -= ViewOnUnloaded;
+            }
+
+            Dispose();
+            platformView.Dispose();
             base.DisconnectHandler(platformView);
         }
     }

--- a/BarcodeScanner.Mobile.Maui/Shared/CameraViewHandler.cs
+++ b/BarcodeScanner.Mobile.Maui/Shared/CameraViewHandler.cs
@@ -39,25 +39,12 @@ namespace BarcodeScanner.Mobile
 
         protected override void ConnectHandler(NativeCameraView nativeView)
         {
-            if (VirtualView is View view)
-            {
-                view.Loaded += ViewOnLoaded;
-                view.Unloaded += ViewOnUnloaded;
-            }
             base.ConnectHandler(nativeView);
+            Connect();
         }
-
-        private void ViewOnUnloaded(object sender, EventArgs e) => Dispose();
-        private void ViewOnLoaded(object sender, EventArgs e) => Connect();
 
         protected override void DisconnectHandler(NativeCameraView platformView)
         {
-            if (VirtualView is View view)
-            {
-                view.Loaded -= ViewOnLoaded;
-                view.Unloaded -= ViewOnUnloaded;
-            }
-
             Dispose();
             platformView.Dispose();
             base.DisconnectHandler(platformView);

--- a/BarcodeScanner.Mobile.XamarinForms/Android/Configuration.cs
+++ b/BarcodeScanner.Mobile.XamarinForms/Android/Configuration.cs
@@ -6,5 +6,9 @@ namespace BarcodeScanner.Mobile
     public static class Configuration
     {
         public static int BarcodeFormats = Barcode.FormatAllFormats;
+        /// <summary>
+        /// In milliseconds, Default is 3000ms
+        /// </summary>
+        public static int AutofocusInterval = 3000;
     }
 }

--- a/BarcodeScanner.Mobile.XamarinForms/Android/Methods.cs
+++ b/BarcodeScanner.Mobile.XamarinForms/Android/Methods.cs
@@ -84,6 +84,9 @@ namespace BarcodeScanner.Mobile
             return formats;
         }
 
+
+        public static void SetAutofocusInterval(int interval) => Configuration.AutofocusInterval = interval;
+
         public static async Task<bool> AskForRequiredPermission()
         {
             try

--- a/SampleApp.Maui/MainPage.xaml
+++ b/SampleApp.Maui/MainPage.xaml
@@ -16,6 +16,7 @@
             <Button Text="Image Capture Demo" Clicked="Button7_Clicked"/>
             <Button Text="OCR Image Capture Demo" Clicked="Button8_Clicked"/>
             <Button Text="OCR from image" Clicked="Button9_Clicked"/>
+            <Button Text="Nested Page" Clicked="Button10_Clicked"/>
         </StackLayout>
     </ScrollView>
 

--- a/SampleApp.Maui/MainPage.xaml.cs
+++ b/SampleApp.Maui/MainPage.xaml.cs
@@ -175,5 +175,15 @@ namespace SampleApp.Maui
             }
 
         }
+
+        private async void Button10_Clicked(object sender, EventArgs e)
+        {
+            //Ask for permission first
+            bool allowed = false;
+            allowed = await Methods.AskForRequiredPermission();
+            if (allowed)
+                Navigation.PushModalAsync(new NavigationPage(new NestedPage.NestedPageDemo()));
+            else DisplayAlert("Alert", "You have to provide Camera permission", "Ok");
+        }
     }
 }

--- a/SampleApp.Maui/NestedPage/NestedPageDemo.xaml
+++ b/SampleApp.Maui/NestedPage/NestedPageDemo.xaml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="SampleApp.Maui.NestedPage.NestedPageDemo"
+             xmlns:gv="clr-namespace:BarcodeScanner.Mobile;assembly=BarcodeScanner.Mobile.Maui"
+             Title="NestedPageDemo">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <StackLayout Orientation="Horizontal" 
+                     Grid.Row="0">
+            <Button Text="Cancel" 
+                    BackgroundColor="#FF0000" 
+                    TextColor="White"
+                    Clicked="CancelButton_Clicked"
+                    HorizontalOptions="StartAndExpand"
+                    CornerRadius="0"/>
+            <Button Text="Next Page"
+                    BackgroundColor="#0075FF"
+                    TextColor="White"
+                    Clicked="NextPage_Clicked"
+                    HorizontalOptions="EndAndExpand"                    
+                    CornerRadius="0"/>
+        </StackLayout>
+
+        <!--Fill the screen with CameraView-->
+        <gv:CameraView OnDetected="CameraView_OnDetected" 
+                       Grid.Row="1"
+                       TorchOn="False" 
+                       VibrationOnDetected="False" 
+                       ScanInterval="50" x:Name="Camera"/>
+
+        <Label Text="Scan QRCode"
+               FontSize="Medium" 
+               HorizontalTextAlignment="Center" 
+               Grid.Row="2"
+               TextColor="Red"/>
+    </Grid>
+</ContentPage>

--- a/SampleApp.Maui/NestedPage/NestedPageDemo.xaml.cs
+++ b/SampleApp.Maui/NestedPage/NestedPageDemo.xaml.cs
@@ -1,0 +1,53 @@
+using BarcodeScanner.Mobile;
+using Microsoft.Maui.Controls.PlatformConfiguration;
+using Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;
+
+namespace SampleApp.Maui.NestedPage;
+
+public partial class NestedPageDemo : ContentPage
+{
+
+    public NestedPageDemo()
+    {
+        InitializeComponent();
+        BarcodeScanner.Mobile.Methods.SetSupportBarcodeFormat(BarcodeFormats.Code39 | BarcodeFormats.QRCode | BarcodeFormats.Code128);
+        On<iOS>().SetUseSafeArea(true);
+    }
+
+    private async void CancelButton_Clicked(object sender, EventArgs e)
+    {
+        await Navigation.PopModalAsync();
+    }
+
+    private void CameraView_OnDetected(object sender, OnDetectedEventArg e)
+    {
+        List<BarcodeResult> obj = e.BarcodeResults;
+
+        string result = string.Empty;
+        for (int i = 0; i < obj.Count; i++)
+        {
+            result += $"Type : {obj[i].BarcodeType}, Value : {obj[i].DisplayValue}{Environment.NewLine}";
+        }
+
+        this.Dispatcher.Dispatch(async () =>
+        {
+            await DisplayAlert("Result", result, "OK");
+            Camera.IsScanning = true;
+        });
+
+    }
+
+    private void NextPage_Clicked(object sender, EventArgs e)
+    {
+        Navigation.PushAsync(new ContentPage()
+        {
+            Content = new Label()
+            {
+                Text = "Dummy nested page",
+                Margin = 20,
+                HorizontalTextAlignment = TextAlignment.Center
+            }
+        });
+    }
+
+}

--- a/SampleApp.Maui/Platforms/Android/AndroidManifest.xml
+++ b/SampleApp.Maui/Platforms/Android/AndroidManifest.xml
@@ -12,7 +12,7 @@
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 	<!-- .net 7 maui has some unresolved permissions issues with api 33. Barcode scanning issues with version 32+ -->
-	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="34" />
+	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="35" />
 	<queries>
 		<intent>
 			<action android:name="android.media.action.IMAGE_CAPTURE" />

--- a/SampleApp.Maui/SampleApp.Maui.csproj
+++ b/SampleApp.Maui/SampleApp.Maui.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net8.0-ios;net8.0-android</TargetFrameworks>
 		<RuntimeIdentifier Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">ios-arm64</RuntimeIdentifier>
 		<PlatformTarget>arm64</PlatformTarget>
 
-		<MauiVersion>8.0.40</MauiVersion>
+		<MauiVersion>8.0.60</MauiVersion>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>SampleApp.Maui</RootNamespace>
 		<UseMaui>true</UseMaui>
@@ -28,7 +28,7 @@
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">12.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
-		
+
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -52,32 +52,42 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-	  <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
-	  <PackageReference Include="Xamarin.AndroidX.Activity" Version="1.9.0.2" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'" />
-	  <PackageReference Include="Xamarin.AndroidX.Activity.Ktx" Version="1.9.0.2" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'" />
-	  <PackageReference Include="BarcodeScanner.Mobile.Maui" Version="8.0.40.1" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
+		<PackageReference Include="Xamarin.AndroidX.Activity" Version="1.9.0.2" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'" />
+		<PackageReference Include="Xamarin.AndroidX.Activity.Ktx" Version="1.9.0.2" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'" />
 	</ItemGroup>
 
 	<ItemGroup>
-	  <Compile Update="OCRImageCapture\OCRImageCaptureDemo.xaml.cs">
-	    <DependentUpon>OCRImageCaptureDemo.xaml</DependentUpon>
-	  </Compile>
+		<ProjectReference Include="..\BarcodeScanner.Mobile.Maui\BarcodeScanner.Mobile.Maui.csproj" />
 	</ItemGroup>
-	
+
+	<ItemGroup>
+		<Compile Update="NestedPage\NestedPageDemo.xaml.cs">
+			<DependentUpon>NestedPageDemo.xaml</DependentUpon>
+		</Compile>
+		<Compile Update="OCRImageCapture\OCRImageCaptureDemo.xaml.cs">
+			<DependentUpon>OCRImageCaptureDemo.xaml</DependentUpon>
+		</Compile>
+	</ItemGroup>
+
 	<ItemGroup>
 
-	  <MauiXaml Update="OCRImageCapture\OCRImageCaptureDemo.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
+		<MauiXaml Update="NestedPage\NestedPageDemo.xaml">
+			<Generator>MSBuild:Compile</Generator>
+		</MauiXaml>
 
-	  <MauiXaml Update="Resources\Styles\Colors.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
+		<MauiXaml Update="OCRImageCapture\OCRImageCaptureDemo.xaml">
+			<Generator>MSBuild:Compile</Generator>
+		</MauiXaml>
 
-	  <MauiXaml Update="Resources\Styles\Styles.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
+		<MauiXaml Update="Resources\Styles\Colors.xaml">
+			<Generator>MSBuild:Compile</Generator>
+		</MauiXaml>
+
+		<MauiXaml Update="Resources\Styles\Styles.xaml">
+			<Generator>MSBuild:Compile</Generator>
+		</MauiXaml>
 
 	</ItemGroup>
 </Project>

--- a/SampleApp.Maui/SampleApp.Maui.csproj
+++ b/SampleApp.Maui/SampleApp.Maui.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0-ios;net8.0-android</TargetFrameworks>
+		<TargetFrameworks>net9.0-ios;net9.0-android</TargetFrameworks>
 		<RuntimeIdentifier Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">ios-arm64</RuntimeIdentifier>
 		<PlatformTarget>arm64</PlatformTarget>
 
-		<MauiVersion>8.0.60</MauiVersion>
+		<MauiVersion>9.0.30</MauiVersion>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>SampleApp.Maui</RootNamespace>
 		<UseMaui>true</UseMaui>
@@ -26,7 +26,7 @@
 		<ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
 		<ApplicationVersion>1</ApplicationVersion>
 
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">12.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">12.2</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
 
 	</PropertyGroup>
@@ -54,8 +54,8 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
-		<PackageReference Include="Xamarin.AndroidX.Activity" Version="1.9.0.2" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'" />
-		<PackageReference Include="Xamarin.AndroidX.Activity.Ktx" Version="1.9.0.2" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'" />
+		<PackageReference Include="Xamarin.AndroidX.Activity" Version="1.9.3.2" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'" />
+		<PackageReference Include="Xamarin.AndroidX.Activity.Ktx" Version="1.9.3.2" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/SampleApp.XF/SampleApp.XF.Android/Resources/Resource.designer.cs
+++ b/SampleApp.XF/SampleApp.XF.Android/Resources/Resource.designer.cs
@@ -53,10 +53,6 @@ namespace SampleApp.XF.Droid
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Animation.design_bottom_sheet_slide_out = global::SampleApp.XF.Droid.Resource.Animation.design_bottom_sheet_slide_out;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Animation.design_snackbar_in = global::SampleApp.XF.Droid.Resource.Animation.design_snackbar_in;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Animation.design_snackbar_out = global::SampleApp.XF.Droid.Resource.Animation.design_snackbar_out;
-			global::BarcodeScanner.Mobile.XamarinForms.Resource.Animation.EnterFromLeft = global::SampleApp.XF.Droid.Resource.Animation.EnterFromLeft;
-			global::BarcodeScanner.Mobile.XamarinForms.Resource.Animation.EnterFromRight = global::SampleApp.XF.Droid.Resource.Animation.EnterFromRight;
-			global::BarcodeScanner.Mobile.XamarinForms.Resource.Animation.ExitToLeft = global::SampleApp.XF.Droid.Resource.Animation.ExitToLeft;
-			global::BarcodeScanner.Mobile.XamarinForms.Resource.Animation.ExitToRight = global::SampleApp.XF.Droid.Resource.Animation.ExitToRight;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Animation.fragment_fast_out_extra_slow_in = global::SampleApp.XF.Droid.Resource.Animation.fragment_fast_out_extra_slow_in;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Animation.mtrl_bottom_sheet_slide_in = global::SampleApp.XF.Droid.Resource.Animation.mtrl_bottom_sheet_slide_in;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Animation.mtrl_bottom_sheet_slide_out = global::SampleApp.XF.Droid.Resource.Animation.mtrl_bottom_sheet_slide_out;
@@ -308,7 +304,6 @@ namespace SampleApp.XF.Droid
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Attribute.collapsedTitleTextAppearance = global::SampleApp.XF.Droid.Resource.Attribute.collapsedTitleTextAppearance;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Attribute.collapseIcon = global::SampleApp.XF.Droid.Resource.Attribute.collapseIcon;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Attribute.collapsingToolbarLayoutStyle = global::SampleApp.XF.Droid.Resource.Attribute.collapsingToolbarLayoutStyle;
-			global::BarcodeScanner.Mobile.XamarinForms.Resource.Attribute.collectionViewStyle = global::SampleApp.XF.Droid.Resource.Attribute.collectionViewStyle;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Attribute.color = global::SampleApp.XF.Droid.Resource.Attribute.color;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Attribute.colorAccent = global::SampleApp.XF.Droid.Resource.Attribute.colorAccent;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Attribute.colorBackgroundFloating = global::SampleApp.XF.Droid.Resource.Attribute.colorBackgroundFloating;
@@ -931,7 +926,6 @@ namespace SampleApp.XF.Droid
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Attribute.scrimAnimationDuration = global::SampleApp.XF.Droid.Resource.Attribute.scrimAnimationDuration;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Attribute.scrimBackground = global::SampleApp.XF.Droid.Resource.Attribute.scrimBackground;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Attribute.scrimVisibleHeightTrigger = global::SampleApp.XF.Droid.Resource.Attribute.scrimVisibleHeightTrigger;
-			global::BarcodeScanner.Mobile.XamarinForms.Resource.Attribute.scrollViewStyle = global::SampleApp.XF.Droid.Resource.Attribute.scrollViewStyle;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Attribute.searchHintIcon = global::SampleApp.XF.Droid.Resource.Attribute.searchHintIcon;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Attribute.searchIcon = global::SampleApp.XF.Droid.Resource.Attribute.searchIcon;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Attribute.searchViewStyle = global::SampleApp.XF.Droid.Resource.Attribute.searchViewStyle;
@@ -2360,8 +2354,6 @@ namespace SampleApp.XF.Droid
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.bestChoice = global::SampleApp.XF.Droid.Resource.Id.bestChoice;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.blocking = global::SampleApp.XF.Droid.Resource.Id.blocking;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.bottom = global::SampleApp.XF.Droid.Resource.Id.bottom;
-			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.bottomtab_navarea = global::SampleApp.XF.Droid.Resource.Id.bottomtab_navarea;
-			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.bottomtab_tabbar = global::SampleApp.XF.Droid.Resource.Id.bottomtab_tabbar;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.BOTTOM_END = global::SampleApp.XF.Droid.Resource.Id.BOTTOM_END;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.BOTTOM_START = global::SampleApp.XF.Droid.Resource.Id.BOTTOM_START;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.bounce = global::SampleApp.XF.Droid.Resource.Id.bounce;
@@ -2474,7 +2466,6 @@ namespace SampleApp.XF.Droid
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.@fixed = global::SampleApp.XF.Droid.Resource.Id.@fixed;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.flip = global::SampleApp.XF.Droid.Resource.Id.flip;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.floating = global::SampleApp.XF.Droid.Resource.Id.floating;
-			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.flyoutcontent_appbar = global::SampleApp.XF.Droid.Resource.Id.flyoutcontent_appbar;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.forever = global::SampleApp.XF.Droid.Resource.Id.forever;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.fragment_container_view_tag = global::SampleApp.XF.Droid.Resource.Id.fragment_container_view_tag;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.frost = global::SampleApp.XF.Droid.Resource.Id.frost;
@@ -2524,10 +2515,6 @@ namespace SampleApp.XF.Droid
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.linear = global::SampleApp.XF.Droid.Resource.Id.linear;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.listMode = global::SampleApp.XF.Droid.Resource.Id.listMode;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.list_item = global::SampleApp.XF.Droid.Resource.Id.list_item;
-			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.main_appbar = global::SampleApp.XF.Droid.Resource.Id.main_appbar;
-			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.main_tablayout = global::SampleApp.XF.Droid.Resource.Id.main_tablayout;
-			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.main_toolbar = global::SampleApp.XF.Droid.Resource.Id.main_toolbar;
-			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.main_viewpager = global::SampleApp.XF.Droid.Resource.Id.main_viewpager;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.masked = global::SampleApp.XF.Droid.Resource.Id.masked;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.match_constraint = global::SampleApp.XF.Droid.Resource.Id.match_constraint;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.match_parent = global::SampleApp.XF.Droid.Resource.Id.match_parent;
@@ -2728,8 +2715,6 @@ namespace SampleApp.XF.Droid
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.select_dialog_listview = global::SampleApp.XF.Droid.Resource.Id.select_dialog_listview;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.sharedValueSet = global::SampleApp.XF.Droid.Resource.Id.sharedValueSet;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.sharedValueUnset = global::SampleApp.XF.Droid.Resource.Id.sharedValueUnset;
-			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.shellcontent_appbar = global::SampleApp.XF.Droid.Resource.Id.shellcontent_appbar;
-			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.shellcontent_toolbar = global::SampleApp.XF.Droid.Resource.Id.shellcontent_toolbar;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.SHIFT = global::SampleApp.XF.Droid.Resource.Id.SHIFT;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.shortcut = global::SampleApp.XF.Droid.Resource.Id.shortcut;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.showCustom = global::SampleApp.XF.Droid.Resource.Id.showCustom;
@@ -2742,7 +2727,6 @@ namespace SampleApp.XF.Droid
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.skipCollapsed = global::SampleApp.XF.Droid.Resource.Id.skipCollapsed;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.skipped = global::SampleApp.XF.Droid.Resource.Id.skipped;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.slide = global::SampleApp.XF.Droid.Resource.Id.slide;
-			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.sliding_tabs = global::SampleApp.XF.Droid.Resource.Id.sliding_tabs;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.snackbar_action = global::SampleApp.XF.Droid.Resource.Id.snackbar_action;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.snackbar_text = global::SampleApp.XF.Droid.Resource.Id.snackbar_text;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.snap = global::SampleApp.XF.Droid.Resource.Id.snap;
@@ -2814,7 +2798,6 @@ namespace SampleApp.XF.Droid
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.titleDividerNoCustom = global::SampleApp.XF.Droid.Resource.Id.titleDividerNoCustom;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.title_template = global::SampleApp.XF.Droid.Resource.Id.title_template;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.toggle = global::SampleApp.XF.Droid.Resource.Id.toggle;
-			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.toolbar = global::SampleApp.XF.Droid.Resource.Id.toolbar;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.top = global::SampleApp.XF.Droid.Resource.Id.top;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.topPanel = global::SampleApp.XF.Droid.Resource.Id.topPanel;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Id.TOP_END = global::SampleApp.XF.Droid.Resource.Id.TOP_END;
@@ -2929,7 +2912,6 @@ namespace SampleApp.XF.Droid
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Layout.abc_search_view = global::SampleApp.XF.Droid.Resource.Layout.abc_search_view;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Layout.abc_select_dialog_material = global::SampleApp.XF.Droid.Resource.Layout.abc_select_dialog_material;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Layout.abc_tooltip = global::SampleApp.XF.Droid.Resource.Layout.abc_tooltip;
-			global::BarcodeScanner.Mobile.XamarinForms.Resource.Layout.BottomTabLayout = global::SampleApp.XF.Droid.Resource.Layout.BottomTabLayout;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Layout.browser_actions_context_menu_page = global::SampleApp.XF.Droid.Resource.Layout.browser_actions_context_menu_page;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Layout.browser_actions_context_menu_row = global::SampleApp.XF.Droid.Resource.Layout.browser_actions_context_menu_row;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Layout.custom_dialog = global::SampleApp.XF.Droid.Resource.Layout.custom_dialog;
@@ -2949,9 +2931,6 @@ namespace SampleApp.XF.Droid
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Layout.design_text_input_end_icon = global::SampleApp.XF.Droid.Resource.Layout.design_text_input_end_icon;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Layout.design_text_input_start_icon = global::SampleApp.XF.Droid.Resource.Layout.design_text_input_start_icon;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Layout.expand_button = global::SampleApp.XF.Droid.Resource.Layout.expand_button;
-			global::BarcodeScanner.Mobile.XamarinForms.Resource.Layout.FallbackTabbarDoNotUse = global::SampleApp.XF.Droid.Resource.Layout.FallbackTabbarDoNotUse;
-			global::BarcodeScanner.Mobile.XamarinForms.Resource.Layout.FallbackToolbarDoNotUse = global::SampleApp.XF.Droid.Resource.Layout.FallbackToolbarDoNotUse;
-			global::BarcodeScanner.Mobile.XamarinForms.Resource.Layout.FlyoutContent = global::SampleApp.XF.Droid.Resource.Layout.FlyoutContent;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Layout.image_frame = global::SampleApp.XF.Droid.Resource.Layout.image_frame;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Layout.ime_base_split_test_activity = global::SampleApp.XF.Droid.Resource.Layout.ime_base_split_test_activity;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Layout.ime_secondary_split_test_activity = global::SampleApp.XF.Droid.Resource.Layout.ime_secondary_split_test_activity;
@@ -3044,13 +3023,10 @@ namespace SampleApp.XF.Droid
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Layout.preference_widget_seekbar_material = global::SampleApp.XF.Droid.Resource.Layout.preference_widget_seekbar_material;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Layout.preference_widget_switch = global::SampleApp.XF.Droid.Resource.Layout.preference_widget_switch;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Layout.preference_widget_switch_compat = global::SampleApp.XF.Droid.Resource.Layout.preference_widget_switch_compat;
-			global::BarcodeScanner.Mobile.XamarinForms.Resource.Layout.RootLayout = global::SampleApp.XF.Droid.Resource.Layout.RootLayout;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Layout.select_dialog_item_material = global::SampleApp.XF.Droid.Resource.Layout.select_dialog_item_material;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Layout.select_dialog_multichoice_material = global::SampleApp.XF.Droid.Resource.Layout.select_dialog_multichoice_material;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Layout.select_dialog_singlechoice_material = global::SampleApp.XF.Droid.Resource.Layout.select_dialog_singlechoice_material;
-			global::BarcodeScanner.Mobile.XamarinForms.Resource.Layout.ShellContent = global::SampleApp.XF.Droid.Resource.Layout.ShellContent;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Layout.support_simple_spinner_dropdown_item = global::SampleApp.XF.Droid.Resource.Layout.support_simple_spinner_dropdown_item;
-			global::BarcodeScanner.Mobile.XamarinForms.Resource.Layout.Tabbar = global::SampleApp.XF.Droid.Resource.Layout.Tabbar;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Layout.test_action_chip = global::SampleApp.XF.Droid.Resource.Layout.test_action_chip;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Layout.test_chip_zero_corner_radius = global::SampleApp.XF.Droid.Resource.Layout.test_chip_zero_corner_radius;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Layout.test_design_checkbox = global::SampleApp.XF.Droid.Resource.Layout.test_design_checkbox;
@@ -3066,7 +3042,6 @@ namespace SampleApp.XF.Droid
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Layout.text_view_with_line_height_from_layout = global::SampleApp.XF.Droid.Resource.Layout.text_view_with_line_height_from_layout;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Layout.text_view_with_line_height_from_style = global::SampleApp.XF.Droid.Resource.Layout.text_view_with_line_height_from_style;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Layout.text_view_with_theme_line_height = global::SampleApp.XF.Droid.Resource.Layout.text_view_with_theme_line_height;
-			global::BarcodeScanner.Mobile.XamarinForms.Resource.Layout.Toolbar = global::SampleApp.XF.Droid.Resource.Layout.Toolbar;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Plurals.mtrl_badge_content_description = global::SampleApp.XF.Droid.Resource.Plurals.mtrl_badge_content_description;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.String.abc_action_bar_home_description = global::SampleApp.XF.Droid.Resource.String.abc_action_bar_home_description;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.String.abc_action_bar_up_description = global::SampleApp.XF.Droid.Resource.String.abc_action_bar_up_description;
@@ -3235,7 +3210,6 @@ namespace SampleApp.XF.Droid
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.String.nav_app_bar_navigate_up_description = global::SampleApp.XF.Droid.Resource.String.nav_app_bar_navigate_up_description;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.String.nav_app_bar_open_drawer_description = global::SampleApp.XF.Droid.Resource.String.nav_app_bar_open_drawer_description;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.String.not_set = global::SampleApp.XF.Droid.Resource.String.not_set;
-			global::BarcodeScanner.Mobile.XamarinForms.Resource.String.overflow_tab_title = global::SampleApp.XF.Droid.Resource.String.overflow_tab_title;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.String.password_toggle_content_description = global::SampleApp.XF.Droid.Resource.String.password_toggle_content_description;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.String.path_password_eye = global::SampleApp.XF.Droid.Resource.String.path_password_eye;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.String.path_password_eye_mask_strike_through = global::SampleApp.XF.Droid.Resource.String.path_password_eye_mask_strike_through;
@@ -3255,7 +3229,6 @@ namespace SampleApp.XF.Droid
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Style.Animation_AppCompat_Tooltip = global::SampleApp.XF.Droid.Resource.Style.Animation_AppCompat_Tooltip;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Style.Animation_Design_BottomSheetDialog = global::SampleApp.XF.Droid.Resource.Style.Animation_Design_BottomSheetDialog;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Style.Animation_MaterialComponents_BottomSheetDialog = global::SampleApp.XF.Droid.Resource.Style.Animation_MaterialComponents_BottomSheetDialog;
-			global::BarcodeScanner.Mobile.XamarinForms.Resource.Style.AppCompatDialogStyle = global::SampleApp.XF.Droid.Resource.Style.AppCompatDialogStyle;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Style.Base_AlertDialog_AppCompat = global::SampleApp.XF.Droid.Resource.Style.Base_AlertDialog_AppCompat;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Style.Base_AlertDialog_AppCompat_Light = global::SampleApp.XF.Droid.Resource.Style.Base_AlertDialog_AppCompat_Light;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Style.Base_Animation_AppCompat_Dialog = global::SampleApp.XF.Droid.Resource.Style.Base_Animation_AppCompat_Dialog;
@@ -3479,10 +3452,7 @@ namespace SampleApp.XF.Droid
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Style.CardView = global::SampleApp.XF.Droid.Resource.Style.CardView;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Style.CardView_Dark = global::SampleApp.XF.Droid.Resource.Style.CardView_Dark;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Style.CardView_Light = global::SampleApp.XF.Droid.Resource.Style.CardView_Light;
-			global::BarcodeScanner.Mobile.XamarinForms.Resource.Style.collectionViewTheme = global::SampleApp.XF.Droid.Resource.Style.collectionViewTheme;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Style.EmptyTheme = global::SampleApp.XF.Droid.Resource.Style.EmptyTheme;
-			global::BarcodeScanner.Mobile.XamarinForms.Resource.Style.MainTheme = global::SampleApp.XF.Droid.Resource.Style.MainTheme;
-			global::BarcodeScanner.Mobile.XamarinForms.Resource.Style.MainTheme_Base = global::SampleApp.XF.Droid.Resource.Style.MainTheme_Base;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Style.MaterialAlertDialog_MaterialComponents = global::SampleApp.XF.Droid.Resource.Style.MaterialAlertDialog_MaterialComponents;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Style.MaterialAlertDialog_MaterialComponents_Body_Text = global::SampleApp.XF.Droid.Resource.Style.MaterialAlertDialog_MaterialComponents_Body_Text;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Style.MaterialAlertDialog_MaterialComponents_Picker_Date_Calendar = global::SampleApp.XF.Droid.Resource.Style.MaterialAlertDialog_MaterialComponents_Picker_Date_Calendar;
@@ -3555,8 +3525,6 @@ namespace SampleApp.XF.Droid
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Style.RtlOverlay_Widget_AppCompat_Search_DropDown_Text = global::SampleApp.XF.Droid.Resource.Style.RtlOverlay_Widget_AppCompat_Search_DropDown_Text;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Style.RtlUnderlay_Widget_AppCompat_ActionButton = global::SampleApp.XF.Droid.Resource.Style.RtlUnderlay_Widget_AppCompat_ActionButton;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Style.RtlUnderlay_Widget_AppCompat_ActionButton_Overflow = global::SampleApp.XF.Droid.Resource.Style.RtlUnderlay_Widget_AppCompat_ActionButton_Overflow;
-			global::BarcodeScanner.Mobile.XamarinForms.Resource.Style.scrollViewScrollBars = global::SampleApp.XF.Droid.Resource.Style.scrollViewScrollBars;
-			global::BarcodeScanner.Mobile.XamarinForms.Resource.Style.scrollViewTheme = global::SampleApp.XF.Droid.Resource.Style.scrollViewTheme;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Style.ShapeAppearanceOverlay = global::SampleApp.XF.Droid.Resource.Style.ShapeAppearanceOverlay;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Style.ShapeAppearanceOverlay_BottomLeftDifferentCornerSize = global::SampleApp.XF.Droid.Resource.Style.ShapeAppearanceOverlay_BottomLeftDifferentCornerSize;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Style.ShapeAppearanceOverlay_BottomRightCut = global::SampleApp.XF.Droid.Resource.Style.ShapeAppearanceOverlay_BottomRightCut;
@@ -5109,8 +5077,6 @@ namespace SampleApp.XF.Droid
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Styleable.Insets_paddingLeftSystemWindowInsets = global::SampleApp.XF.Droid.Resource.Styleable.Insets_paddingLeftSystemWindowInsets;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Styleable.Insets_paddingRightSystemWindowInsets = global::SampleApp.XF.Droid.Resource.Styleable.Insets_paddingRightSystemWindowInsets;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Styleable.Insets_paddingTopSystemWindowInsets = global::SampleApp.XF.Droid.Resource.Styleable.Insets_paddingTopSystemWindowInsets;
-			global::BarcodeScanner.Mobile.XamarinForms.Resource.Styleable.ItemsViewRendererTheme = global::SampleApp.XF.Droid.Resource.Styleable.ItemsViewRendererTheme;
-			global::BarcodeScanner.Mobile.XamarinForms.Resource.Styleable.ItemsViewRendererTheme_collectionViewStyle = global::SampleApp.XF.Droid.Resource.Styleable.ItemsViewRendererTheme_collectionViewStyle;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Styleable.KeyAttribute = global::SampleApp.XF.Droid.Resource.Styleable.KeyAttribute;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Styleable.KeyAttribute_android_alpha = global::SampleApp.XF.Droid.Resource.Styleable.KeyAttribute_android_alpha;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Styleable.KeyAttribute_android_elevation = global::SampleApp.XF.Droid.Resource.Styleable.KeyAttribute_android_elevation;
@@ -5736,8 +5702,6 @@ namespace SampleApp.XF.Droid
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Styleable.ScrimInsetsFrameLayout_insetForeground = global::SampleApp.XF.Droid.Resource.Styleable.ScrimInsetsFrameLayout_insetForeground;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Styleable.ScrollingViewBehavior_Layout = global::SampleApp.XF.Droid.Resource.Styleable.ScrollingViewBehavior_Layout;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Styleable.ScrollingViewBehavior_Layout_behavior_overlapTop = global::SampleApp.XF.Droid.Resource.Styleable.ScrollingViewBehavior_Layout_behavior_overlapTop;
-			global::BarcodeScanner.Mobile.XamarinForms.Resource.Styleable.ScrollViewRendererTheme = global::SampleApp.XF.Droid.Resource.Styleable.ScrollViewRendererTheme;
-			global::BarcodeScanner.Mobile.XamarinForms.Resource.Styleable.ScrollViewRendererTheme_scrollViewStyle = global::SampleApp.XF.Droid.Resource.Styleable.ScrollViewRendererTheme_scrollViewStyle;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Styleable.SearchView = global::SampleApp.XF.Droid.Resource.Styleable.SearchView;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Styleable.SearchView_android_focusable = global::SampleApp.XF.Droid.Resource.Styleable.SearchView_android_focusable;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Styleable.SearchView_android_imeOptions = global::SampleApp.XF.Droid.Resource.Styleable.SearchView_android_imeOptions;
@@ -6131,7 +6095,6 @@ namespace SampleApp.XF.Droid
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Xml.standalone_badge_gravity_bottom_start = global::SampleApp.XF.Droid.Resource.Xml.standalone_badge_gravity_bottom_start;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Xml.standalone_badge_gravity_top_start = global::SampleApp.XF.Droid.Resource.Xml.standalone_badge_gravity_top_start;
 			global::BarcodeScanner.Mobile.XamarinForms.Resource.Xml.standalone_badge_offset = global::SampleApp.XF.Droid.Resource.Xml.standalone_badge_offset;
-			global::BarcodeScanner.Mobile.XamarinForms.Resource.Xml.xamarin_essentials_fileprovider_file_paths = global::SampleApp.XF.Droid.Resource.Xml.xamarin_essentials_fileprovider_file_paths;
 			global::Plugin.Media.Resource.Attribute.alpha = global::SampleApp.XF.Droid.Resource.Attribute.alpha;
 			global::Plugin.Media.Resource.Attribute.font = global::SampleApp.XF.Droid.Resource.Attribute.font;
 			global::Plugin.Media.Resource.Attribute.fontProviderAuthority = global::SampleApp.XF.Droid.Resource.Attribute.fontProviderAuthority;

--- a/SampleApp.XF/SampleApp.XF.Android/SampleApp.XF.Android.csproj
+++ b/SampleApp.XF/SampleApp.XF.Android/SampleApp.XF.Android.csproj
@@ -57,12 +57,10 @@
     <Reference Include="System.Numerics.Vectors" />
   </ItemGroup>
   <ItemGroup>
-   <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.6.2.1">
-   </PackageReference>
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.6.2.1">
+    </PackageReference>
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2662" />
     <PackageReference Include="Xamarin.Essentials" Version="1.8.1" />
-	  <PackageReference Include="BarcodeScanner.Mobile.XamarinForms" Version="6.4.0.2" />
-
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />
@@ -94,7 +92,11 @@
     <Folder Include="Resources\drawable\" />
   </ItemGroup>
   <ItemGroup>
-      <ProjectReference Include="..\SampleApp.XF\SampleApp.XF.csproj">
+    <ProjectReference Include="..\..\BarcodeScanner.Mobile.XamarinForms\BarcodeScanner.Mobile.XamarinForms.csproj">
+      <Project>{61557ff8-acd6-4c66-a5b1-b0d461a3dad3}</Project>
+      <Name>BarcodeScanner.Mobile.XamarinForms</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\SampleApp.XF\SampleApp.XF.csproj">
       <Project>{3C1F0740-EA98-4954-9173-240188AEC83B}</Project>
       <Name>SampleApp.XF</Name>
     </ProjectReference>

--- a/SampleApp.XF/SampleApp.XF.Android/SampleApp.XF.Android.csproj
+++ b/SampleApp.XF/SampleApp.XF.Android/SampleApp.XF.Android.csproj
@@ -95,6 +95,7 @@
     <ProjectReference Include="..\..\BarcodeScanner.Mobile.XamarinForms\BarcodeScanner.Mobile.XamarinForms.csproj">
       <Project>{61557ff8-acd6-4c66-a5b1-b0d461a3dad3}</Project>
       <Name>BarcodeScanner.Mobile.XamarinForms</Name>
+      <IsAppExtension>false</IsAppExtension>
     </ProjectReference>
     <ProjectReference Include="..\SampleApp.XF\SampleApp.XF.csproj">
       <Project>{3C1F0740-EA98-4954-9173-240188AEC83B}</Project>

--- a/SampleApp.XF/SampleApp.XF.iOS/SampleApp.XF.iOS.csproj
+++ b/SampleApp.XF/SampleApp.XF.iOS/SampleApp.XF.iOS.csproj
@@ -129,10 +129,13 @@
     <PackageReference Include="Xam.Plugin.Media" Version="6.0.2" />
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2662" />
     <PackageReference Include="Xamarin.Essentials" Version="1.8.1" />
-	  <PackageReference Include="BarcodeScanner.Mobile.XamarinForms" Version="6.4.0.2" />
   </ItemGroup>
-  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" /> 
   <ItemGroup>
+    <ProjectReference Include="..\..\BarcodeScanner.Mobile.XamarinForms\BarcodeScanner.Mobile.XamarinForms.csproj">
+      <Project>{61557ff8-acd6-4c66-a5b1-b0d461a3dad3}</Project>
+      <Name>BarcodeScanner.Mobile.XamarinForms</Name>
+    </ProjectReference>
     <ProjectReference Include="..\SampleApp.XF\SampleApp.XF.csproj">
       <Project>{3C1F0740-EA98-4954-9173-240188AEC83B}</Project>
       <Name>SampleApp.XF</Name>

--- a/SampleApp.XF/SampleApp.XF/SampleApp.XF.csproj
+++ b/SampleApp.XF/SampleApp.XF/SampleApp.XF.csproj
@@ -15,8 +15,10 @@
 		<PackageReference Include="Xam.Plugin.Media" Version="6.0.2" />
 		<PackageReference Include="Xamarin.Forms" Version="5.0.0.2662" />
 		<PackageReference Include="Xamarin.Essentials" Version="1.8.1" />
-	  	<PackageReference Include="BarcodeScanner.Mobile.XamarinForms" Version="6.4.0.2" />
+	</ItemGroup>
 
+	<ItemGroup>
+	  <ProjectReference Include="..\..\BarcodeScanner.Mobile.XamarinForms\BarcodeScanner.Mobile.XamarinForms.csproj" />
 	</ItemGroup>
 	<ItemGroup>
 		<EmbeddedResource Update="Mvvm\MvvmDemo.xaml">


### PR DESCRIPTION
Fix for navigating back from nested page (there is an issue when disconnecting handler), switched to look into loaded and unloaded events

Possible fix for #99 thanks to [istanko](https://github.com/JimmyPun610/BarcodeScanner.Mobile/issues/99#issuecomment-1174826862) comment and #243 

Prevent infinity loop for handling focus and add the ability to set autofocus interval.

I also faced #239 , I was not able to even open a solution, I noticed that it is starting to "work" by commenting on this line in `SampleApp.XF.iOS.csporj` but not sure how to fix it for the XF iOS app...
`<Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />`

UPDATE:

Updated to NET9.