### PR TITLE
Set focus level on camera init

### DIFF
--- a/BarcodeScanner.Mobile.Maui/Platforms/Android/CameraViewHandler.android.cs
+++ b/BarcodeScanner.Mobile.Maui/Platforms/Android/CameraViewHandler.android.cs
@@ -95,6 +95,7 @@ namespace BarcodeScanner.Mobile
 
                 HandleTorch();
                 HandleAutoFocus();
+                HandleZoom();
             }
             catch (Exception exc)
             {

--- a/BarcodeScanner.Mobile.Maui/Platforms/iOS/CameraViewHandler.ios.cs
+++ b/BarcodeScanner.Mobile.Maui/Platforms/iOS/CameraViewHandler.ios.cs
@@ -75,6 +75,7 @@ namespace BarcodeScanner.Mobile
             CaptureSession.StartRunning();
             HandleTorch();
             SetFocusMode();
+            HandleZoom();
         }
 
         public void Dispose()

--- a/BarcodeScanner.Mobile.XamarinForms/Android/Renderer/CameraViewRenderer.cs
+++ b/BarcodeScanner.Mobile.XamarinForms/Android/Renderer/CameraViewRenderer.cs
@@ -136,6 +136,7 @@ namespace BarcodeScanner.Mobile.Renderer
                 HandleCustomPreviewSize(preview);
                 HandleTorch();
                 HandleAutoFoucs();
+                HandleZoom();
             }
             catch (Exception exc)
             {

--- a/BarcodeScanner.Mobile.XamarinForms/iOS/UICameraPreview.cs
+++ b/BarcodeScanner.Mobile.XamarinForms/iOS/UICameraPreview.cs
@@ -224,6 +224,7 @@ namespace BarcodeScanner.Mobile
                     if (renderer.Element.TorchOn && !IsTorchOn())
                         ToggleFlashlight();
                     SetFocusMode();
+                    SetZoom(renderer.Element.Zoom);
                 }
             });
         }


### PR DESCRIPTION
Focus level was only set to the camera handler on property change and only after the camera had been initialized. This made it impossible to use a preferred zoom level which may be needed for different cameras.